### PR TITLE
fix: feature flags in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,9 @@ futures-buffered ={ version = "0.2.9", optional = true }
 # for AbortOnDropHandle
 n0-future = { workspace = true, optional = true }
 
+[target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
+quinn = { workspace = true, optional = true, features = ["runtime-tokio"] }
+
 [dev-dependencies]
 tracing-subscriber = { workspace = true, features = ["fmt"] }
 # used in the derive example. This must not be a main crate dep or else it will be circular!
@@ -80,6 +83,7 @@ postcard = { version = "1.1.1", default-features = false }
 serde = { version = "1", default-features = false }
 tracing = { version = "0.1.41", default-features = false }
 n0-future = { version = "0.1.2", default-features = false }
-tracing-subscriber = { version = "0.3.19", default-features = false }
+tracing-subscriber = { version = "0.3.19" }
 iroh = { version = "0.34" }
 quinn = { package = "iroh-quinn", version = "0.13.0", default-features = false }
+

--- a/irpc-iroh/Cargo.toml
+++ b/irpc-iroh/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "irpc-iroh"
 version = "0.2.0"
-edition = "2024"
+edition = "2021"
 authors = ["Rüdiger Klaehn <rklaehn@protonmail.com>", "n0 team"]
 keywords = ["api", "protocol", "network", "rpc"]
 categories = ["network-programming"]

--- a/irpc-iroh/examples/derive.rs
+++ b/irpc-iroh/examples/derive.rs
@@ -2,13 +2,13 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use anyhow::Context;
 use irpc::{
-    Client, LocalSender, Request, Service, WithChannels,
     channel::{oneshot, spsc},
     rpc::Handler,
+    Client, LocalSender, Request, Service, WithChannels,
 };
 // Import the macro
 use irpc_derive::rpc_requests;
-use irpc_iroh::{IrohRemoteConnection, listen};
+use irpc_iroh::{listen, IrohRemoteConnection};
 use n0_future::task::{self, AbortOnDropHandle};
 use serde::{Deserialize, Serialize};
 use tracing::info;

--- a/irpc-iroh/src/lib.rs
+++ b/irpc-iroh/src/lib.rs
@@ -2,9 +2,9 @@ use std::{io, sync::Arc};
 
 use iroh::endpoint::{ConnectionError, RecvStream, SendStream};
 use irpc::{
-    RequestError,
     rpc::{Handler, RemoteConnection},
     util::AsyncReadVarintExt,
+    RequestError,
 };
 
 /// A connection to a remote service.
@@ -90,7 +90,7 @@ mod multithreaded {
 #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 use multithreaded::*;
 use serde::de::DeserializeOwned;
-use tracing::{Instrument, trace, trace_span, warn};
+use tracing::{trace, trace_span, warn, Instrument};
 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
 use wasm_browser::*;
 


### PR DESCRIPTION
I think the recent push to make irpc work in wasm broke running the examples with remote support. This fixes it.

To try: `cargo run --example derive`, without this PR it panics with "on async runtime found", with this PR it works.

Also set edition to 2021 in irpc-iroh to not needlessly raise MSRV.