### PR TITLE
feat: add methods on `Client` to issue requests on either local or remote APIs

### DIFF
--- a/examples/derive.rs
+++ b/examples/derive.rs
@@ -4,10 +4,10 @@ use std::{
     sync::Arc,
 };
 
-use anyhow::bail;
+use anyhow::{Context, Result};
 use irpc::{
     channel::{oneshot, spsc},
-    rpc::{listen, Handler},
+    rpc::Handler,
     util::{make_client_endpoint, make_server_endpoint},
     Client, LocalSender, Request, Service, WithChannels,
 };
@@ -37,6 +37,15 @@ struct Set {
     value: String,
 }
 
+impl From<(String, String)> for Set {
+    fn from((key, value): (String, String)) -> Self {
+        Self { key, value }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct SetMany;
+
 // Use the macro to generate both the StorageProtocol and StorageMessage enums
 // plus implement Channels for each type
 #[rpc_requests(StorageService, message = StorageMessage)]
@@ -46,6 +55,8 @@ enum StorageProtocol {
     Get(Get),
     #[rpc(tx=oneshot::Sender<()>)]
     Set(Set),
+    #[rpc(tx=oneshot::Sender<u64>, rx=spsc::Receiver<(String, String)>)]
+    SetMany(SetMany),
     #[rpc(tx=spsc::Sender<String>)]
     List(List),
 }
@@ -56,7 +67,7 @@ struct StorageActor {
 }
 
 impl StorageActor {
-    pub fn local() -> StorageApi {
+    pub fn spawn() -> StorageApi {
         let (tx, rx) = tokio::sync::mpsc::channel(1);
         let actor = Self {
             recv: rx,
@@ -88,6 +99,16 @@ impl StorageActor {
                 self.state.insert(inner.key, inner.value);
                 tx.send(()).await.ok();
             }
+            StorageMessage::SetMany(set) => {
+                info!("set-many {:?}", set);
+                let WithChannels { mut rx, tx, .. } = set;
+                let mut count = 0;
+                while let Ok(Some((key, value))) = rx.recv().await {
+                    self.state.insert(key, value);
+                    count += 1;
+                }
+                tx.send(count).await.ok();
+            }
             StorageMessage::List(list) => {
                 info!("list {:?}", list);
                 let WithChannels { mut tx, .. } = list;
@@ -106,27 +127,25 @@ struct StorageApi {
 }
 
 impl StorageApi {
-    pub fn connect(endpoint: quinn::Endpoint, addr: SocketAddr) -> anyhow::Result<StorageApi> {
+    pub fn connect(endpoint: quinn::Endpoint, addr: SocketAddr) -> Result<StorageApi> {
         Ok(StorageApi {
             inner: Client::quinn(endpoint, addr),
         })
     }
 
-    pub fn listen(&self, endpoint: quinn::Endpoint) -> anyhow::Result<AbortOnDropHandle<()>> {
-        let Some(local) = self.inner.local() else {
-            bail!("cannot listen on a remote service");
-        };
-        let handler: Handler<StorageProtocol> = Arc::new(move |msg, _, tx| {
+    pub fn listen(&self, endpoint: quinn::Endpoint) -> Result<AbortOnDropHandle<()>> {
+        let local = self.inner.local().context("cannot listen on remote API")?;
+        let handler: Handler<StorageProtocol> = Arc::new(move |msg, rx, tx| {
             let local = local.clone();
             Box::pin(match msg {
                 StorageProtocol::Get(msg) => local.send((msg, tx)),
                 StorageProtocol::Set(msg) => local.send((msg, tx)),
+                StorageProtocol::SetMany(msg) => local.send((msg, tx, rx)),
                 StorageProtocol::List(msg) => local.send((msg, tx)),
             })
         });
-        Ok(AbortOnDropHandle::new(task::spawn(listen(
-            endpoint, handler,
-        ))))
+        let join_handle = task::spawn(irpc::rpc::listen(endpoint, handler));
+        Ok(AbortOnDropHandle::new(join_handle))
     }
 
     pub async fn get(&self, key: String) -> anyhow::Result<oneshot::Receiver<Option<String>>> {
@@ -173,53 +192,80 @@ impl StorageApi {
             }
         }
     }
+
+    pub async fn set_many(
+        &self,
+    ) -> Result<(spsc::Sender<(String, String)>, oneshot::Receiver<u64>)> {
+        let msg = SetMany;
+        match self.inner.request().await? {
+            Request::Local(request) => {
+                let (req_tx, req_rx) = spsc::channel(16);
+                let (res_tx, res_rx) = oneshot::channel();
+                request.send((msg, res_tx, req_rx)).await?;
+                Ok((req_tx, res_rx))
+            }
+            Request::Remote(request) => {
+                let (tx, rx) = request.write(msg).await?;
+                Ok((tx.into(), rx.into()))
+            }
+        }
+    }
 }
 
-async fn local() -> anyhow::Result<()> {
-    let api = StorageActor::local();
+async fn client_demo(api: StorageApi) -> anyhow::Result<()> {
     api.set("hello".to_string(), "world".to_string())
         .await?
         .await?;
     let value = api.get("hello".to_string()).await?.await?;
+    println!("hello = {:?}", value);
+
+    let (mut tx, rx) = api.set_many().await?;
+    for i in 0..3 {
+        tx.send((format!("key{i}"), format!("value{i}"))).await?;
+    }
+    drop(tx);
+    let count = rx.await?;
+    println!("set-many: {count} values set");
+
     let mut list = api.list().await?;
     while let Some(value) = list.recv().await? {
         println!("list value = {:?}", value);
     }
-    println!("value = {:?}", value);
     Ok(())
 }
 
-async fn remote() -> anyhow::Result<()> {
+async fn local() -> Result<()> {
+    let api = StorageActor::spawn();
+    client_demo(api).await?;
+    Ok(())
+}
+
+async fn remote() -> Result<()> {
     let port = 10113;
-    let (server, cert) =
-        make_server_endpoint(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port).into())?;
-    let client =
+    let addr: SocketAddr = SocketAddrV4::new(Ipv4Addr::LOCALHOST, port).into();
+
+    let (server_handle, cert) = {
+        let (endpoint, cert) = make_server_endpoint(addr)?;
+        let api = StorageActor::spawn();
+        let handle = api.listen(endpoint)?;
+        (handle, cert)
+    };
+
+    let endpoint =
         make_client_endpoint(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0).into(), &[&cert])?;
-    let store = StorageActor::local();
-    let handle = store.listen(server)?;
-    let api = StorageApi::connect(client, SocketAddrV4::new(Ipv4Addr::LOCALHOST, port).into())?;
-    api.set("hello".to_string(), "world".to_string())
-        .await?
-        .await?;
-    api.set("goodbye".to_string(), "world".to_string())
-        .await?
-        .await?;
-    let value = api.get("hello".to_string()).await?.await?;
-    println!("value = {:?}", value);
-    let mut list = api.list().await?;
-    while let Some(value) = list.recv().await? {
-        println!("list value = {:?}", value);
-    }
-    drop(handle);
+    let api = StorageApi::connect(endpoint, addr)?;
+    client_demo(api).await?;
+
+    drop(server_handle);
     Ok(())
 }
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt().init();
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
     println!("Local use");
     local().await?;
     println!("Remote use");
-    remote().await?;
+    remote().await.unwrap();
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -785,7 +785,6 @@ impl<M, R, S> Client<M, R, S> {
             async move {
                 match cloned {
                     Request::Local(tx) => Ok(Request::Local(tx.into())),
-                    #[cfg(feature = "rpc")]
                     Request::Remote(conn) => {
                         let (send, recv) = conn.open_bi().await?;
                         Ok(Request::Remote(rpc::RemoteSender::new(send, recv)))
@@ -801,6 +800,138 @@ impl<M, R, S> Client<M, R, S> {
             let tx = tx.clone().into();
             async move { Ok(Request::Local(tx)) }
         }
+    }
+
+    /// Performs a request for which the server returns a oneshot receiver.
+    pub async fn rpc<Req, Res>(&self, msg: Req) -> Result<Res, Error>
+    where
+        S: Service,
+        M: From<WithChannels<Req, S>> + Send + Sync + Unpin + 'static,
+        R: From<Req> + Serialize + 'static,
+        Req: Channels<S, Tx = channel::oneshot::Sender<Res>, Rx = NoReceiver>,
+        Res: RpcMessage,
+    {
+        let recv: channel::oneshot::Receiver<Res> = match self.request().await? {
+            Request::Local(request) => {
+                let (tx, rx) = channel::oneshot::channel();
+                request.send((msg, tx)).await?;
+                rx
+            }
+            #[cfg(not(feature = "rpc"))]
+            Request::Remote(_request) => unreachable!(),
+            #[cfg(feature = "rpc")]
+            Request::Remote(request) => {
+                let (_tx, rx) = request.write(msg).await?;
+                rx.into()
+            }
+        };
+        let res = recv.await?;
+        Ok(res)
+    }
+
+    /// Performs a request for which the server returns a spsc receiver.
+    pub async fn server_streaming<Req, Res>(
+        &self,
+        msg: Req,
+        local_response_cap: usize,
+    ) -> Result<channel::spsc::Receiver<Res>, Error>
+    where
+        S: Service,
+        M: From<WithChannels<Req, S>> + Send + Sync + Unpin + 'static,
+        R: From<Req> + Serialize + 'static,
+        Req: Channels<S, Tx = channel::spsc::Sender<Res>, Rx = NoReceiver>,
+        Res: RpcMessage,
+    {
+        let recv: channel::spsc::Receiver<Res> = match self.request().await? {
+            Request::Local(request) => {
+                let (tx, rx) = channel::spsc::channel(local_response_cap);
+                request.send((msg, tx)).await?;
+                rx
+            }
+            #[cfg(not(feature = "rpc"))]
+            Request::Remote(_request) => unreachable!(),
+            #[cfg(feature = "rpc")]
+            Request::Remote(request) => {
+                let (_tx, rx) = request.write(msg).await?;
+                rx.into()
+            }
+        };
+        Ok(recv)
+    }
+
+    /// Performs a request for which the client can send updates.
+    pub async fn client_streaming<Req, Update, Res>(
+        &self,
+        msg: Req,
+        local_update_cap: usize,
+    ) -> Result<
+        (
+            channel::spsc::Sender<Update>,
+            channel::oneshot::Receiver<Res>,
+        ),
+        Error,
+    >
+    where
+        S: Service,
+        M: From<WithChannels<Req, S>> + Send + Sync + Unpin + 'static,
+        R: From<Req> + Serialize + 'static,
+        Req: Channels<S, Tx = channel::oneshot::Sender<Res>, Rx = channel::spsc::Receiver<Update>>,
+        Update: RpcMessage,
+        Res: RpcMessage,
+    {
+        let (update_tx, res_rx): (
+            channel::spsc::Sender<Update>,
+            channel::oneshot::Receiver<Res>,
+        ) = match self.request().await? {
+            Request::Local(request) => {
+                let (req_tx, req_rx) = channel::spsc::channel(local_update_cap);
+                let (res_tx, res_rx) = channel::oneshot::channel();
+                request.send((msg, res_tx, req_rx)).await?;
+                (req_tx, res_rx)
+            }
+            #[cfg(not(feature = "rpc"))]
+            Request::Remote(_request) => unreachable!(),
+            #[cfg(feature = "rpc")]
+            Request::Remote(request) => {
+                let (tx, rx) = request.write(msg).await?;
+                (tx.into(), rx.into())
+            }
+        };
+        Ok((update_tx, res_rx))
+    }
+
+    /// Performs a request for which the client can send updates, and the server returns a spsc receiver.
+    pub async fn bidi_streaming<Req, Update, Res>(
+        &self,
+        msg: Req,
+        local_update_cap: usize,
+        local_response_cap: usize,
+    ) -> Result<(channel::spsc::Sender<Update>, channel::spsc::Receiver<Res>), Error>
+    where
+        S: Service,
+        M: From<WithChannels<Req, S>> + Send + Sync + Unpin + 'static,
+        R: From<Req> + Serialize + 'static,
+        Req: Channels<S, Tx = channel::spsc::Sender<Res>, Rx = channel::spsc::Receiver<Update>>,
+        Update: RpcMessage,
+        Res: RpcMessage,
+    {
+        let (update_tx, res_rx): (channel::spsc::Sender<Update>, channel::spsc::Receiver<Res>) =
+            match self.request().await? {
+                Request::Local(request) => {
+                    let (update_tx, update_rx) = channel::spsc::channel(local_update_cap);
+                    let (res_tx, res_rx) = channel::spsc::channel(local_response_cap);
+                    request.send((msg, res_tx, update_rx)).await?;
+                    (update_tx, res_rx)
+                }
+                #[cfg(not(feature = "rpc"))]
+                Request::Remote(_request) => unreachable!(),
+                #[cfg(feature = "rpc")]
+                Request::Remote(request) => {
+                    let (tx, rx) = request.write(msg).await?;
+                    (tx.into(), rx.into())
+                }
+            };
+        Ok((update_tx, res_rx))
     }
 }
 
@@ -1090,6 +1221,13 @@ pub mod rpc {
                 io::Result::Ok(msg)
             };
             oneshot::Receiver::from(|| fut)
+        }
+    }
+
+    impl From<quinn::RecvStream> for crate::channel::none::NoReceiver {
+        fn from(read: quinn::RecvStream) -> Self {
+            drop(read);
+            Self
         }
     }
 


### PR DESCRIPTION
This adds `Client::rpc`, `Client::server_streaming`,  `Client::client_streaming` and `Client::bidi_streaming` methods to `Client.`
With these methods, we can skip the boilerplate of having to match on local or remote requests when implementing the clientside API, at least for the common case where you don't want to customize stream settings.
The streaming methods take an argument to set the capacity for the channels when the local API is in use.

See [this commit](https://github.com/n0-computer/irpc/pull/5/commits/33c2e9335800586455cafcd7c3c9279e9926e42c) for how this reduces the boilerplate.

(The first commit adds a `set_many` method to the derive example to demonstrate client-side streaming, and does a few cleanups to the example).