### PR TITLE
fix: build on wasm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,12 @@ jobs:
           toolchain: ${{ matrix.channel }}
           targets: ${{ matrix.target.toolchain }}
       - uses: swatinem/rust-cache@v2
-      - name: cargo test
+      - name: cargo test (all features)
         run: cargo test --locked --workspace --all-features --bins --tests --examples
+      - name: cargo test (default features)
+        run: cargo test --locked --workspace --bins --tests --examples
+      - name: cargo test (no default features)
+        run: cargo test --locked --workspace --no-default-features --bins --tests --examples
 
   test-release:
     runs-on: ${{ matrix.target.os }}
@@ -91,6 +95,27 @@ jobs:
       - uses: swatinem/rust-cache@v2
       - name: cargo test
         run: cargo test --release --locked --workspace --all-features --bins --tests --examples
+        
+  wasm_build:
+      name: Build wasm32
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout sources
+          uses: actions/checkout@v4
+        - name: Install stable toolchain
+          uses: dtolnay/rust-toolchain@stable
+        - name: Add wasm target
+          run: rustup target add wasm32-unknown-unknown
+        - name: Install wasm-tools
+          uses: bytecodealliance/actions/wasm-tools/setup@v1
+        - name: wasm32 build
+          run: cargo build --target wasm32-unknown-unknown
+        # If the Wasm file contains any 'import "env"' declarations, then
+        # some non-Wasm-compatible code made it into the final code.
+        - name: Ensure no 'import "env"' in iroh-relay Wasm
+          run: |
+            ! wasm-tools print --skeleton target/wasm32-unknown-unknown/debug/irpc.wasm | grep 'import "env"'
+
 
   # Checks correct runtime deps and features are requested by not including dev-dependencies.
   check-deps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
     branches:
       - main
 
-
 concurrency:
   group: tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -64,6 +63,10 @@ jobs:
         run: cargo test --locked --workspace --bins --tests --examples
       - name: cargo test (no default features)
         run: cargo test --locked --workspace --no-default-features --bins --tests --examples
+      - name: cargo check (feature message_spans)
+        run: cargo check --no-default-features --features message_spans
+      - name: cargo check (feature rpc)
+        run: cargo check --no-default-features --features rpc
 
   test-release:
     runs-on: ${{ matrix.target.os }}
@@ -95,27 +98,26 @@ jobs:
       - uses: swatinem/rust-cache@v2
       - name: cargo test
         run: cargo test --release --locked --workspace --all-features --bins --tests --examples
-        
-  wasm_build:
-      name: Build wasm32
-      runs-on: ubuntu-latest
-      steps:
-        - name: Checkout sources
-          uses: actions/checkout@v4
-        - name: Install stable toolchain
-          uses: dtolnay/rust-toolchain@stable
-        - name: Add wasm target
-          run: rustup target add wasm32-unknown-unknown
-        - name: Install wasm-tools
-          uses: bytecodealliance/actions/wasm-tools/setup@v1
-        - name: wasm32 build
-          run: cargo build --target wasm32-unknown-unknown
-        # If the Wasm file contains any 'import "env"' declarations, then
-        # some non-Wasm-compatible code made it into the final code.
-        - name: Ensure no 'import "env"' in iroh-relay Wasm
-          run: |
-            ! wasm-tools print --skeleton target/wasm32-unknown-unknown/debug/irpc.wasm | grep 'import "env"'
 
+  wasm_build:
+    name: Build wasm32
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Add wasm target
+        run: rustup target add wasm32-unknown-unknown
+      - name: Install wasm-tools
+        uses: bytecodealliance/actions/wasm-tools/setup@v1
+      - name: wasm32 build
+        run: cargo build --target wasm32-unknown-unknown
+      # If the Wasm file contains any 'import "env"' declarations, then
+      # some non-Wasm-compatible code made it into the final code.
+      - name: Ensure no 'import "env"' in iroh-relay Wasm
+        run: |
+          ! wasm-tools print --skeleton target/wasm32-unknown-unknown/debug/irpc.wasm | grep 'import "env"'
 
   # Checks correct runtime deps and features are requested by not including dev-dependencies.
   check-deps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ anyhow = { workspace = true, optional = true }
 # used in the benches
 futures-buffered ={ version = "0.2.9", optional = true }
 # for AbortOnDropHandle
-n0-future = { workspace = true, optional = true }
+n0-future = { workspace = true }
 futures-util = { workspace = true, optional = true }
 
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
@@ -60,7 +60,7 @@ trybuild = "1.0.104"
 
 [features]
 # enable the remote transport
-rpc = ["dep:quinn", "dep:postcard", "dep:anyhow", "dep:smallvec", "dep:tracing", "dep:n0-future", "tokio/io-util"]
+rpc = ["dep:quinn", "dep:postcard", "dep:anyhow", "dep:smallvec", "dep:tracing", "tokio/io-util"]
 # add test utilities
 quinn_endpoint_setup = ["rpc", "dep:rustls", "dep:rcgen", "dep:anyhow", "dep:futures-buffered", "quinn/rustls-ring"]
 # pick up parent span when creating channel messages

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ rpc = ["dep:quinn", "dep:postcard", "dep:anyhow", "dep:smallvec", "dep:tracing",
 # add test utilities
 quinn_endpoint_setup = ["rpc", "dep:rustls", "dep:rcgen", "dep:anyhow", "dep:futures-buffered", "quinn/rustls-ring"]
 # pick up parent span when creating channel messages
-message_spans = []
+message_spans = ["dep:tracing"]
 stream = ["dep:futures-util"]
 default = ["rpc", "quinn_endpoint_setup", "message_spans", "stream"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,6 @@
 #![cfg_attr(quicrpc_docsrs, feature(doc_cfg))]
 use std::{fmt::Debug, future::Future, io, marker::PhantomData, ops::Deref};
 
-use n0_future::boxed::BoxFuture;
 use sealed::Sealed;
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -141,7 +140,7 @@ pub mod channel {
     pub mod oneshot {
         use std::{fmt::Debug, future::Future, io, pin::Pin, task};
 
-        use n0_future::boxed::BoxFuture;
+        use n0_future::future::Boxed as BoxFuture;
 
         use super::{RecvError, SendError};
         use crate::util::FusedOneshotReceiver;
@@ -179,7 +178,7 @@ pub mod channel {
         /// Remote receivers are always boxed, since for remote communication the boxing
         /// overhead is negligible. However, boxing can also be used for local communication,
         /// e.g. when applying a transform or filter to the message before receiving it.
-        pub type BoxedReceiver<T> = crate::BoxFuture<io::Result<T>>;
+        pub type BoxedReceiver<T> = BoxFuture<io::Result<T>>;
 
         /// A oneshot sender.
         ///
@@ -1093,7 +1092,7 @@ pub mod rpc {
     //! Module for cross-process RPC using [`quinn`].
     use std::{fmt::Debug, future::Future, io, marker::PhantomData, pin::Pin, sync::Arc};
 
-    use n0_future::task::JoinSet;
+    use n0_future::{future::Boxed as BoxFuture, task::JoinSet};
     use quinn::ConnectionError;
     use serde::{de::DeserializeOwned, Serialize};
     use smallvec::SmallVec;
@@ -1107,7 +1106,7 @@ pub mod rpc {
             RecvError, SendError,
         },
         util::{now_or_never, AsyncReadVarintExt, WriteVarintExt},
-        BoxFuture, RequestError, RpcMessage,
+        RequestError, RpcMessage,
     };
 
     /// Error that can occur when writing the initial message when doing a


### PR DESCRIPTION
* Adds CI to build with `--no-default-features`, `--all-features`, and default features. 
* Fixes build with `--no-default-features`, it was broken because `n0-future` was incorrectly listed as optional dependency (but is now always required)
* Fixes build for `wasm32-unknown-unknown`. I'm not 100% sure if the fix is accurate: On `main`  the build fails because a few functions that return `impl Future + Send` failed to build because they included a `n0_future::boxed::BoxFuture`, which is `Send` on non-wasm targets only and `!Send` on wasm. However I don't think it hurts for us to have those be `Send`  on wasm as well, as we don't do anything local-only, do we? So by changing the `BoxFuture` to unconditionally be the `Send` version, this now builds on wasm.

With these changes, https://github.com/n0-computer/iroh-gossip/pull/67 now compiles on wasm as well.