### PR TITLE
feat: reexport the rpc_requests macro in irpc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,14 +41,14 @@ futures-buffered ={ version = "0.2.9", optional = true }
 # for AbortOnDropHandle
 n0-future = { workspace = true }
 futures-util = { workspace = true, optional = true }
+# for the derive reexport/feature
+irpc-derive = { version = "0.2.3", path = "./irpc-derive", optional = true }
 
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
 quinn = { workspace = true, optional = true, features = ["runtime-tokio"] }
 
 [dev-dependencies]
 tracing-subscriber = { workspace = true, features = ["fmt"] }
-# used in the derive example. This must not be a main crate dep or else it will be circular!
-irpc-derive = { version = "0.2.3", path = "./irpc-derive" }
 # just convenient for the enum definitions, in the manual example
 derive_more = { version = "2", features = ["from"] }
 # we need full for example main etc.
@@ -66,7 +66,8 @@ quinn_endpoint_setup = ["rpc", "dep:rustls", "dep:rcgen", "dep:anyhow", "dep:fut
 # pick up parent span when creating channel messages
 message_spans = ["dep:tracing"]
 stream = ["dep:futures-util"]
-default = ["rpc", "quinn_endpoint_setup", "message_spans", "stream"]
+derive = ["dep:irpc-derive"]
+default = ["rpc", "quinn_endpoint_setup", "message_spans", "stream", "derive"]
 
 [workspace]
 members = ["irpc-derive", "irpc-iroh"]

--- a/examples/compute.rs
+++ b/examples/compute.rs
@@ -11,8 +11,8 @@ use irpc::{
     rpc::{listen, Handler},
     util::{make_client_endpoint, make_server_endpoint},
     Client, LocalSender, Request, Service, WithChannels,
+    rpc_requests,
 };
-use irpc_derive::rpc_requests;
 use n0_future::{
     stream::StreamExt,
     task::{self, AbortOnDropHandle},

--- a/examples/derive.rs
+++ b/examples/derive.rs
@@ -8,11 +8,11 @@ use anyhow::{Context, Result};
 use irpc::{
     channel::{oneshot, spsc},
     rpc::Handler,
+    rpc_requests,
     util::{make_client_endpoint, make_server_endpoint},
     Client, Error, LocalSender, Service, WithChannels,
 };
 // Import the macro
-use irpc_derive::rpc_requests;
 use n0_future::task::{self, AbortOnDropHandle};
 use serde::{Deserialize, Serialize};
 use tracing::info;

--- a/irpc-iroh/examples/derive.rs
+++ b/irpc-iroh/examples/derive.rs
@@ -63,9 +63,9 @@ mod storage {
         channel::{oneshot, spsc},
         rpc::Handler,
         Client, LocalSender, Service, WithChannels,
+        rpc_requests,
     };
     // Import the macro
-    use irpc_derive::rpc_requests;
     use irpc_iroh::{IrohProtocol, IrohRemoteConnection};
     use serde::{Deserialize, Serialize};
     use tracing::info;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,9 @@
 #![cfg_attr(quicrpc_docsrs, feature(doc_cfg))]
 use std::{fmt::Debug, future::Future, io, marker::PhantomData, ops::Deref};
 
+#[cfg(feature = "derive")]
+#[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "derive")))]
+pub use irpc_derive::rpc_requests;
 use sealed::Sealed;
 use serde::{de::DeserializeOwned, Serialize};
 

--- a/tests/compile_fail/duplicate_type.rs
+++ b/tests/compile_fail/duplicate_type.rs
@@ -1,4 +1,4 @@
-use irpc_derive::rpc_requests;
+use irpc::rpc_requests;
 
 #[rpc_requests(Service, Msg)]
 enum Enum {

--- a/tests/compile_fail/extra_attr_types.rs
+++ b/tests/compile_fail/extra_attr_types.rs
@@ -1,4 +1,4 @@
-use irpc_derive::rpc_requests;
+use irpc::rpc_requests;
 
 #[rpc_requests(Service, Msg)]
 enum Enum {

--- a/tests/compile_fail/multiple_fields.rs
+++ b/tests/compile_fail/multiple_fields.rs
@@ -1,4 +1,4 @@
-use irpc_derive::rpc_requests;
+use irpc::rpc_requests;
 
 #[rpc_requests(Service, Msg)]
 enum Enum {

--- a/tests/compile_fail/named_enum.rs
+++ b/tests/compile_fail/named_enum.rs
@@ -1,4 +1,4 @@
-use irpc_derive::rpc_requests;
+use irpc::rpc_requests;
 
 #[rpc_requests(Service, Msg)]
 enum Enum {

--- a/tests/compile_fail/non_enum.rs
+++ b/tests/compile_fail/non_enum.rs
@@ -1,4 +1,4 @@
-use irpc_derive::rpc_requests;
+use irpc::rpc_requests;
 
 #[rpc_requests(Service, Msg)]
 struct Foo;

--- a/tests/compile_fail/wrong_attr_types.rs
+++ b/tests/compile_fail/wrong_attr_types.rs
@@ -1,4 +1,4 @@
-use irpc_derive::rpc_requests;
+use irpc::rpc_requests;
 
 #[rpc_requests(Service, Msg)]
 enum Enum {

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -1,5 +1,5 @@
 use irpc::channel::{none::NoSender, oneshot};
-use irpc_derive::rpc_requests;
+use irpc::rpc_requests;
 use serde::{Deserialize, Serialize};
 
 #[test]


### PR DESCRIPTION
(when the derive feature is enabled). This is so people don't have to separately import irpc_derive. It used to be a problem bc irpc_derive depended on irpc, but it isn't anymore.

Not sure if this is the nicest way, but it does mean that you no longer have to separately depend on irpc-derive