### PR TITLE
Add irpc::Result after all, and use it in the examples.

### DIFF
--- a/examples/compute.rs
+++ b/examples/compute.rs
@@ -9,9 +9,9 @@ use futures_buffered::BufferedStreamExt;
 use irpc::{
     channel::{oneshot, spsc},
     rpc::{listen, Handler},
+    rpc_requests,
     util::{make_client_endpoint, make_server_endpoint},
     Client, LocalSender, Request, Service, WithChannels,
-    rpc_requests,
 };
 use n0_future::{
     stream::StreamExt,

--- a/examples/derive.rs
+++ b/examples/derive.rs
@@ -10,7 +10,7 @@ use irpc::{
     rpc::Handler,
     rpc_requests,
     util::{make_client_endpoint, make_server_endpoint},
-    Client, Error, LocalSender, Service, WithChannels,
+    Client, LocalSender, Service, WithChannels,
 };
 // Import the macro
 use n0_future::task::{self, AbortOnDropHandle};
@@ -148,21 +148,21 @@ impl StorageApi {
         Ok(AbortOnDropHandle::new(join_handle))
     }
 
-    pub async fn get(&self, key: String) -> Result<Option<String>, Error> {
+    pub async fn get(&self, key: String) -> irpc::Result<Option<String>> {
         self.inner.rpc(Get { key }).await
     }
 
-    pub async fn list(&self) -> Result<spsc::Receiver<String>, Error> {
+    pub async fn list(&self) -> irpc::Result<spsc::Receiver<String>> {
         self.inner.server_streaming(List, 16).await
     }
 
-    pub async fn set(&self, key: String, value: String) -> Result<(), Error> {
+    pub async fn set(&self, key: String, value: String) -> irpc::Result<()> {
         self.inner.rpc(Set { key, value }).await
     }
 
     pub async fn set_many(
         &self,
-    ) -> Result<(spsc::Sender<(String, String)>, oneshot::Receiver<u64>), Error> {
+    ) -> irpc::Result<(spsc::Sender<(String, String)>, oneshot::Receiver<u64>)> {
         self.inner.client_streaming(SetMany, 4).await
     }
 }

--- a/irpc-iroh/examples/derive.rs
+++ b/irpc-iroh/examples/derive.rs
@@ -62,8 +62,7 @@ mod storage {
     use irpc::{
         channel::{oneshot, spsc},
         rpc::Handler,
-        Client, LocalSender, Service, WithChannels,
-        rpc_requests,
+        rpc_requests, Client, LocalSender, Service, WithChannels,
     };
     // Import the macro
     use irpc_iroh::{IrohProtocol, IrohRemoteConnection};
@@ -187,15 +186,15 @@ mod storage {
             Ok(IrohProtocol::new(handler))
         }
 
-        pub async fn get(&self, key: String) -> Result<Option<String>, irpc::Error> {
+        pub async fn get(&self, key: String) -> irpc::Result<Option<String>> {
             self.inner.rpc(Get { key }).await
         }
 
-        pub async fn list(&self) -> Result<spsc::Receiver<String>, irpc::Error> {
+        pub async fn list(&self) -> irpc::Result<spsc::Receiver<String>> {
             self.inner.server_streaming(List, 10).await
         }
 
-        pub async fn set(&self, key: String, value: String) -> Result<(), irpc::Error> {
+        pub async fn set(&self, key: String, value: String) -> irpc::Result<()> {
             let msg = Set { key, value };
             self.inner.rpc(msg).await
         }

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -1,5 +1,7 @@
-use irpc::channel::{none::NoSender, oneshot};
-use irpc::rpc_requests;
+use irpc::{
+    channel::{none::NoSender, oneshot},
+    rpc_requests,
+};
 use serde::{Deserialize, Serialize};
 
 #[test]


### PR DESCRIPTION
I hesitated with doing this initially, but I think it is useful after all...