### PR TITLE
refactor!: rename `spsc` module to `mpsc`

### DIFF
--- a/examples/compute.rs
+++ b/examples/compute.rs
@@ -7,7 +7,7 @@ use std::{
 use anyhow::bail;
 use futures_buffered::BufferedStreamExt;
 use irpc::{
-    channel::{oneshot, spsc},
+    channel::{oneshot, mpsc},
     rpc::{listen, Handler},
     rpc_requests,
     util::{make_client_endpoint, make_server_endpoint},
@@ -61,11 +61,11 @@ enum ComputeRequest {
 enum ComputeProtocol {
     #[rpc(tx=oneshot::Sender<u128>)]
     Sqr(Sqr),
-    #[rpc(rx=spsc::Receiver<i64>, tx=oneshot::Sender<i64>)]
+    #[rpc(rx=mpsc::Receiver<i64>, tx=oneshot::Sender<i64>)]
     Sum(Sum),
-    #[rpc(tx=spsc::Sender<u64>)]
+    #[rpc(tx=mpsc::Sender<u64>)]
     Fibonacci(Fibonacci),
-    #[rpc(rx=spsc::Receiver<u64>, tx=spsc::Sender<u64>)]
+    #[rpc(rx=mpsc::Receiver<u64>, tx=mpsc::Sender<u64>)]
     Multiply(Multiply),
 }
 
@@ -200,11 +200,11 @@ impl ComputeApi {
         }
     }
 
-    pub async fn sum(&self) -> anyhow::Result<(spsc::Sender<i64>, oneshot::Receiver<i64>)> {
+    pub async fn sum(&self) -> anyhow::Result<(mpsc::Sender<i64>, oneshot::Receiver<i64>)> {
         let msg = Sum;
         match self.inner.request().await? {
             Request::Local(request) => {
-                let (num_tx, num_rx) = spsc::channel(10);
+                let (num_tx, num_rx) = mpsc::channel(10);
                 let (sum_tx, sum_rx) = oneshot::channel();
                 request.send((msg, sum_tx, num_rx)).await?;
                 Ok((num_tx, sum_rx))
@@ -216,11 +216,11 @@ impl ComputeApi {
         }
     }
 
-    pub async fn fibonacci(&self, max: u64) -> anyhow::Result<spsc::Receiver<u64>> {
+    pub async fn fibonacci(&self, max: u64) -> anyhow::Result<mpsc::Receiver<u64>> {
         let msg = Fibonacci { max };
         match self.inner.request().await? {
             Request::Local(request) => {
-                let (tx, rx) = spsc::channel(128);
+                let (tx, rx) = mpsc::channel(128);
                 request.send((msg, tx)).await?;
                 Ok(rx)
             }
@@ -234,12 +234,12 @@ impl ComputeApi {
     pub async fn multiply(
         &self,
         initial: u64,
-    ) -> anyhow::Result<(spsc::Sender<u64>, spsc::Receiver<u64>)> {
+    ) -> anyhow::Result<(mpsc::Sender<u64>, mpsc::Receiver<u64>)> {
         let msg = Multiply { initial };
         match self.inner.request().await? {
             Request::Local(request) => {
-                let (in_tx, in_rx) = spsc::channel(128);
-                let (out_tx, out_rx) = spsc::channel(128);
+                let (in_tx, in_rx) = mpsc::channel(128);
+                let (out_tx, out_rx) = mpsc::channel(128);
                 request.send((msg, out_tx, in_rx)).await?;
                 Ok((in_tx, out_rx))
             }

--- a/examples/compute.rs
+++ b/examples/compute.rs
@@ -7,7 +7,7 @@ use std::{
 use anyhow::bail;
 use futures_buffered::BufferedStreamExt;
 use irpc::{
-    channel::{oneshot, mpsc},
+    channel::{mpsc, oneshot},
     rpc::{listen, Handler},
     rpc_requests,
     util::{make_client_endpoint, make_server_endpoint},

--- a/examples/derive.rs
+++ b/examples/derive.rs
@@ -6,7 +6,7 @@ use std::{
 
 use anyhow::{Context, Result};
 use irpc::{
-    channel::{oneshot, mpsc},
+    channel::{mpsc, oneshot},
     rpc::Handler,
     rpc_requests,
     util::{make_client_endpoint, make_server_endpoint},

--- a/examples/storage.rs
+++ b/examples/storage.rs
@@ -6,7 +6,7 @@ use std::{
 
 use anyhow::bail;
 use irpc::{
-    channel::{none::NoReceiver, oneshot, mpsc},
+    channel::{mpsc, none::NoReceiver, oneshot},
     rpc::{listen, Handler},
     util::{make_client_endpoint, make_server_endpoint},
     Channels, Client, LocalSender, Request, Service, WithChannels,

--- a/irpc-iroh/examples/auth.rs
+++ b/irpc-iroh/examples/auth.rs
@@ -72,7 +72,7 @@ mod storage {
         Endpoint,
     };
     use irpc::{
-        channel::{oneshot, mpsc},
+        channel::{mpsc, oneshot},
         Client, Service, WithChannels,
     };
     // Import the macro

--- a/irpc-iroh/examples/auth.rs
+++ b/irpc-iroh/examples/auth.rs
@@ -72,7 +72,7 @@ mod storage {
         Endpoint,
     };
     use irpc::{
-        channel::{oneshot, spsc},
+        channel::{oneshot, mpsc},
         Client, Service, WithChannels,
     };
     // Import the macro
@@ -122,9 +122,9 @@ mod storage {
         Get(Get),
         #[rpc(tx=oneshot::Sender<()>)]
         Set(Set),
-        #[rpc(tx=oneshot::Sender<u64>, rx=spsc::Receiver<(String, String)>)]
+        #[rpc(tx=oneshot::Sender<u64>, rx=mpsc::Receiver<(String, String)>)]
         SetMany(SetMany),
-        #[rpc(tx=spsc::Sender<String>)]
+        #[rpc(tx=mpsc::Sender<String>)]
         List(List),
     }
 
@@ -265,7 +265,7 @@ mod storage {
             self.inner.rpc(Get { key }).await
         }
 
-        pub async fn list(&self) -> Result<spsc::Receiver<String>, irpc::Error> {
+        pub async fn list(&self) -> Result<mpsc::Receiver<String>, irpc::Error> {
             self.inner.server_streaming(List, 10).await
         }
 

--- a/irpc-iroh/examples/derive.rs
+++ b/irpc-iroh/examples/derive.rs
@@ -60,7 +60,7 @@ mod storage {
     use anyhow::{Context, Result};
     use iroh::{protocol::ProtocolHandler, Endpoint};
     use irpc::{
-        channel::{oneshot, spsc},
+        channel::{oneshot, mpsc},
         rpc::Handler,
         rpc_requests, Client, LocalSender, Service, WithChannels,
     };
@@ -97,7 +97,7 @@ mod storage {
         Get(Get),
         #[rpc(tx=oneshot::Sender<()>)]
         Set(Set),
-        #[rpc(tx=spsc::Sender<String>)]
+        #[rpc(tx=mpsc::Sender<String>)]
         List(List),
     }
 
@@ -190,7 +190,7 @@ mod storage {
             self.inner.rpc(Get { key }).await
         }
 
-        pub async fn list(&self) -> irpc::Result<spsc::Receiver<String>> {
+        pub async fn list(&self) -> irpc::Result<mpsc::Receiver<String>> {
             self.inner.server_streaming(List, 10).await
         }
 

--- a/irpc-iroh/examples/derive.rs
+++ b/irpc-iroh/examples/derive.rs
@@ -60,7 +60,7 @@ mod storage {
     use anyhow::{Context, Result};
     use iroh::{protocol::ProtocolHandler, Endpoint};
     use irpc::{
-        channel::{oneshot, mpsc},
+        channel::{mpsc, oneshot},
         rpc::Handler,
         rpc_requests, Client, LocalSender, Service, WithChannels,
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1118,10 +1118,9 @@ pub mod rpc {
 
     use crate::{
         channel::{
-            none::NoSender,
-            oneshot,
             mpsc::{self, DynReceiver, DynSender},
-            RecvError, SendError,
+            none::NoSender,
+            oneshot, RecvError, SendError,
         },
         util::{now_or_never, AsyncReadVarintExt, WriteVarintExt},
         RequestError, RpcMessage,

--- a/tests/mpsc_sender.rs
+++ b/tests/mpsc_sender.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use irpc::{
-    channel::{spsc, SendError},
+    channel::{mpsc, SendError},
     util::{make_client_endpoint, make_server_endpoint},
 };
 use quinn::Endpoint;
@@ -36,7 +36,7 @@ async fn mpsc_sender_clone_closed_error() -> TestResult<()> {
     });
     let conn = client.connect(server_addr, "localhost")?.await?;
     let (send, _) = conn.open_bi().await?;
-    let send1 = spsc::Sender::<Vec<u8>>::from(send);
+    let send1 = mpsc::Sender::<Vec<u8>>::from(send);
     let send2 = send1.clone();
     let send3 = send1.clone();
     let second_client = tokio::spawn(async move {
@@ -82,7 +82,7 @@ async fn mpsc_sender_clone_drop_error() -> TestResult<()> {
     });
     let conn = client.connect(server_addr, "localhost")?.await?;
     let (send, _) = conn.open_bi().await?;
-    let send1 = spsc::Sender::<Vec<u8>>::from(send);
+    let send1 = mpsc::Sender::<Vec<u8>>::from(send);
     let send2 = send1.clone();
     let send3 = send1.clone();
     let second_client = tokio::spawn(async move {


### PR DESCRIPTION
#25 made the `spsc::Sender` cloneable, so it is now a multi-producer channel. This renames the module from `spsc` to `mpsc`.

## Breaking changes

* `irpc::channel::spsc` module is renamed to `irpc::channel::mpsc`