### PR TITLE
refactor: Add associated types to `Service`, use protocol enum as `Service`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,16 +57,18 @@ jobs:
           toolchain: ${{ matrix.channel }}
           targets: ${{ matrix.target.toolchain }}
       - uses: swatinem/rust-cache@v2
-      - name: cargo test (all features)
+      - name: cargo test (workspace, all features)
         run: cargo test --locked --workspace --all-features --bins --tests --examples
-      - name: cargo test (default features)
+      - name: cargo test (workspace, default features)
         run: cargo test --locked --workspace --bins --tests --examples
-      - name: cargo test (no default features)
+      - name: cargo test (workspace, no default features)
         run: cargo test --locked --workspace --no-default-features --bins --tests --examples
-      - name: cargo check (feature message_spans)
-        run: cargo check --no-default-features --features message_spans
-      - name: cargo check (feature rpc)
-        run: cargo check --no-default-features --features rpc
+      - name: cargo check (irpc, no default features)
+        run: cargo check --locked --no-default-features --bins --tests --examples
+      - name: cargo check (irpc, feature spans)
+        run: cargo check --locked --no-default-features --features spans --bins --tests --examples
+      - name: cargo check (irpc, feature rpc)
+        run: cargo check --locked --no-default-features --features rpc --bins --tests --examples
 
   test-release:
     runs-on: ${{ matrix.target.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,8 @@ jobs:
         run: cargo test --locked --workspace --no-default-features --bins --tests --examples
       - name: cargo check (irpc, no default features)
         run: cargo check --locked --no-default-features --bins --tests --examples
+      - name: cargo check (irpc, feature derive)
+        run: cargo check --locked --no-default-features --features derive --bins --tests --examples
       - name: cargo check (irpc, feature spans)
         run: cargo check --locked --no-default-features --features spans --bins --tests --examples
       - name: cargo check (irpc, feature rpc)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,10 +65,26 @@ rpc = ["dep:quinn", "dep:postcard", "dep:anyhow", "dep:smallvec", "dep:tracing",
 # add test utilities
 quinn_endpoint_setup = ["rpc", "dep:rustls", "dep:rcgen", "dep:anyhow", "dep:futures-buffered", "quinn/rustls-ring"]
 # pick up parent span when creating channel messages
-message_spans = ["dep:tracing"]
+spans = ["dep:tracing"]
 stream = ["dep:futures-util"]
 derive = ["dep:irpc-derive"]
-default = ["rpc", "quinn_endpoint_setup", "message_spans", "stream", "derive"]
+default = ["rpc", "quinn_endpoint_setup", "spans", "stream", "derive"]
+
+[[example]]
+name = "derive"
+required-features = ["rpc", "derive", "quinn_endpoint_setup"]
+
+[[example]]
+name = "compute"
+required-features = ["rpc", "derive", "quinn_endpoint_setup"]
+
+[[example]]
+name = "local"
+required-features = ["derive"]
+
+[[example]]
+name = "storage"
+required-features = ["rpc", "quinn_endpoint_setup"]
 
 [workspace]
 members = ["irpc-derive", "irpc-iroh"]
@@ -84,7 +100,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(quicrpc_docsrs)"] }
 anyhow = { version = "1.0.98" }
 tokio = { version = "1.44", default-features = false }
 postcard = { version = "1.1.1", default-features = false }
-serde = { version = "1", default-features = false }
+serde = { version = "1", default-features = false, features = ["derive"] }
 tracing = { version = "0.1.41", default-features = false }
 n0-future = { version = "0.1.2", default-features = false }
 tracing-subscriber = { version = "0.3.19" }

--- a/examples/compute.rs
+++ b/examples/compute.rs
@@ -21,7 +21,7 @@ use thousands::Separable;
 use tracing::trace;
 
 // Define the protocol and message enums using the macro
-#[rpc_requests(ComputeMessage)]
+#[rpc_requests(message = ComputeMessage)]
 #[derive(Serialize, Deserialize, Debug)]
 enum ComputeProtocol {
     #[rpc(tx=oneshot::Sender<u128>)]

--- a/examples/compute.rs
+++ b/examples/compute.rs
@@ -7,7 +7,7 @@ use anyhow::bail;
 use futures_buffered::BufferedStreamExt;
 use irpc::{
     channel::{mpsc, oneshot},
-    rpc::{listen, MessageWithChannels},
+    rpc::{listen, RemoteService},
     rpc_requests,
     util::{make_client_endpoint, make_server_endpoint},
     Client, LocalSender, Request, WithChannels,
@@ -164,7 +164,7 @@ impl ComputeApi {
         let Some(local) = self.inner.local() else {
             bail!("cannot listen on a remote service");
         };
-        let handler = ComputeMessage::forwarding_handler(local);
+        let handler = ComputeProtocol::forwarding_handler(local);
         Ok(AbortOnDropHandle::new(task::spawn(listen(
             endpoint, handler,
         ))))

--- a/examples/compute.rs
+++ b/examples/compute.rs
@@ -163,7 +163,7 @@ impl ComputeApi {
         let Some(local) = self.inner.as_local() else {
             bail!("cannot listen on a remote service");
         };
-        let handler = ComputeProtocol::forwarding_handler(local);
+        let handler = ComputeProtocol::remote_handler(local);
         Ok(AbortOnDropHandle::new(task::spawn(listen(
             endpoint, handler,
         ))))

--- a/examples/derive.rs
+++ b/examples/derive.rs
@@ -9,18 +9,12 @@ use irpc::{
     rpc::MessageWithChannels,
     rpc_requests,
     util::{make_client_endpoint, make_server_endpoint},
-    Client, LocalSender, Service, WithChannels,
+    Client, LocalSender, WithChannels,
 };
 // Import the macro
 use n0_future::task::{self, AbortOnDropHandle};
 use serde::{Deserialize, Serialize};
 use tracing::info;
-
-/// A simple storage service, just to try it out
-#[derive(Debug, Clone, Copy)]
-struct StorageService;
-
-impl Service for StorageService {}
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Get {
@@ -47,8 +41,8 @@ struct SetMany;
 
 // Use the macro to generate both the StorageProtocol and StorageMessage enums
 // plus implement Channels for each type
-#[rpc_requests(StorageService, message = StorageMessage)]
-#[derive(Serialize, Deserialize)]
+#[rpc_requests(StorageMessage)]
+#[derive(Serialize, Deserialize, Debug)]
 enum StorageProtocol {
     #[rpc(tx=oneshot::Sender<Option<String>>)]
     Get(Get),
@@ -73,7 +67,7 @@ impl StorageActor {
             state: BTreeMap::new(),
         };
         n0_future::task::spawn(actor.run());
-        let local = LocalSender::<StorageMessage, StorageService>::from(tx);
+        let local = LocalSender::<StorageProtocol>::from(tx);
         StorageApi {
             inner: local.into(),
         }
@@ -122,7 +116,7 @@ impl StorageActor {
 }
 
 struct StorageApi {
-    inner: Client<StorageMessage, StorageProtocol, StorageService>,
+    inner: Client<StorageProtocol>,
 }
 
 impl StorageApi {

--- a/examples/derive.rs
+++ b/examples/derive.rs
@@ -132,7 +132,7 @@ impl StorageApi {
             .context("cannot listen on remote API")?;
         let join_handle = task::spawn(irpc::rpc::listen(
             endpoint,
-            StorageProtocol::forwarding_handler(local),
+            StorageProtocol::remote_handler(local),
         ));
         Ok(AbortOnDropHandle::new(join_handle))
     }

--- a/examples/derive.rs
+++ b/examples/derive.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "rpc")]
-
 use std::{
     collections::BTreeMap,
     net::{Ipv4Addr, SocketAddr, SocketAddrV4},

--- a/examples/derive.rs
+++ b/examples/derive.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "rpc")]
+
 use std::{
     collections::BTreeMap,
     net::{Ipv4Addr, SocketAddr, SocketAddrV4},
@@ -41,7 +43,7 @@ struct SetMany;
 
 // Use the macro to generate both the StorageProtocol and StorageMessage enums
 // plus implement Channels for each type
-#[rpc_requests(StorageMessage)]
+#[rpc_requests(message = StorageMessage)]
 #[derive(Serialize, Deserialize, Debug)]
 enum StorageProtocol {
     #[rpc(tx=oneshot::Sender<Option<String>>)]

--- a/examples/derive.rs
+++ b/examples/derive.rs
@@ -6,7 +6,7 @@ use std::{
 use anyhow::{Context, Result};
 use irpc::{
     channel::{mpsc, oneshot},
-    rpc::MessageWithChannels,
+    rpc::RemoteService,
     rpc_requests,
     util::{make_client_endpoint, make_server_endpoint},
     Client, LocalSender, WithChannels,
@@ -130,7 +130,7 @@ impl StorageApi {
         let local = self.inner.local().context("cannot listen on remote API")?;
         let join_handle = task::spawn(irpc::rpc::listen(
             endpoint,
-            StorageMessage::forwarding_handler(local),
+            StorageProtocol::forwarding_handler(local),
         ));
         Ok(AbortOnDropHandle::new(join_handle))
     }

--- a/examples/local.rs
+++ b/examples/local.rs
@@ -1,0 +1,105 @@
+//! This demonstrates using irpc with the derive macro but without the rpc feature
+//! for local-only use. Run with:
+//! ```
+//! cargo run --example local --no-default-features --features derive
+//! ```
+
+use std::collections::BTreeMap;
+
+use irpc::{channel::oneshot, rpc_requests, Client, WithChannels};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Get {
+    key: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct List;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Set {
+    key: String,
+    value: String,
+}
+
+impl From<(String, String)> for Set {
+    fn from((key, value): (String, String)) -> Self {
+        Self { key, value }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct SetMany;
+
+#[rpc_requests(message = StorageMessage, no_rpc, no_spans)]
+#[derive(Serialize, Deserialize, Debug)]
+enum StorageProtocol {
+    #[rpc(tx=oneshot::Sender<Option<String>>)]
+    Get(Get),
+    #[rpc(tx=oneshot::Sender<()>)]
+    Set(Set),
+}
+
+struct Actor {
+    recv: tokio::sync::mpsc::Receiver<StorageMessage>,
+    state: BTreeMap<String, String>,
+}
+
+impl Actor {
+    async fn run(mut self) {
+        while let Some(msg) = self.recv.recv().await {
+            self.handle(msg).await;
+        }
+    }
+
+    async fn handle(&mut self, msg: StorageMessage) {
+        match msg {
+            StorageMessage::Get(get) => {
+                let WithChannels { tx, inner, .. } = get;
+                tx.send(self.state.get(&inner.key).cloned()).await.ok();
+            }
+            StorageMessage::Set(set) => {
+                let WithChannels { tx, inner, .. } = set;
+                self.state.insert(inner.key, inner.value);
+                tx.send(()).await.ok();
+            }
+        }
+    }
+}
+
+struct StorageApi {
+    inner: Client<StorageProtocol>,
+}
+
+impl StorageApi {
+    pub fn spawn() -> StorageApi {
+        let (tx, rx) = tokio::sync::mpsc::channel(1);
+        let actor = Actor {
+            recv: rx,
+            state: BTreeMap::new(),
+        };
+        n0_future::task::spawn(actor.run());
+        StorageApi {
+            inner: Client::local(tx),
+        }
+    }
+
+    pub async fn get(&self, key: String) -> irpc::Result<Option<String>> {
+        self.inner.rpc(Get { key }).await
+    }
+
+    pub async fn set(&self, key: String, value: String) -> irpc::Result<()> {
+        self.inner.rpc(Set { key, value }).await
+    }
+}
+
+#[tokio::main]
+async fn main() -> irpc::Result<()> {
+    tracing_subscriber::fmt::init();
+    let api = StorageApi::spawn();
+    api.set("hello".to_string(), "world".to_string()).await?;
+    let value = api.get("hello".to_string()).await?;
+    println!("get: hello = {value:?}");
+    Ok(())
+}

--- a/irpc-derive/src/lib.rs
+++ b/irpc-derive/src/lib.rs
@@ -355,11 +355,8 @@ pub fn rpc_requests(attr: TokenStream, item: TokenStream) -> TokenStream {
         let parent_span_impl = generate_parent_span_impl(&message_enum_name, &variant_names);
 
         // Generate From implementations for the message enum (only for variants with rpc attributes)
-        let message_from_impls = generate_message_enum_from_impls(
-            &message_enum_name,
-            &variants_with_attr,
-            service_name,
-        );
+        let message_from_impls =
+            generate_message_enum_from_impls(&message_enum_name, &variants_with_attr, service_name);
 
         let message_from_quic_streams =
             generate_message_from_wire_impl(&message_enum_name, enum_name, &variants_with_attr);

--- a/irpc-derive/src/lib.rs
+++ b/irpc-derive/src/lib.rs
@@ -134,16 +134,16 @@ fn generate_message_from_wire_impl(
         });
 
     quote! {
-        impl ::irpc::rpc::MessageWithChannels for #message_enum_name {
-            type WireMessage = #proto_enum_name;
+        impl ::irpc::rpc::RemoteService for #proto_enum_name {
             fn from_wire(
                 msg: Self::WireMessage,
                 rx: ::irpc::rpc::quinn::RecvStream,
-                tx: ::irpc::rpc::quinn::SendStream) -> Self {
-                    match msg {
-                        #(#variants),*
-                    }
+                tx: ::irpc::rpc::quinn::SendStream
+            ) -> Self::Message {
+                match msg {
+                    #(#variants),*
                 }
+            }
         }
     }
 }

--- a/irpc-derive/src/lib.rs
+++ b/irpc-derive/src/lib.rs
@@ -64,8 +64,8 @@ fn generate_channels_impl(
     Ok(res)
 }
 
-/// Generates From implementations for cases with rpc attributes
-fn generate_case_from_impls(
+/// Generates From implementations for protocol enum variants.
+fn generate_protocol_enum_from_impls(
     enum_name: &Ident,
     variants_with_attr: &[(Ident, Type)],
 ) -> TokenStream2 {
@@ -90,7 +90,7 @@ fn generate_case_from_impls(
     impls
 }
 
-/// Generate From implementations for message enum variants
+/// Generates From implementations for message enum variants.
 fn generate_message_enum_from_impls(
     message_enum_name: &Ident,
     variants_with_attr: &[(Ident, Type)],
@@ -268,7 +268,8 @@ pub fn rpc_requests(attr: TokenStream, item: TokenStream) -> TokenStream {
     }
 
     // Generate From implementations for the original enum (only for variants with rpc attributes)
-    let original_from_impls = generate_case_from_impls(enum_name, &variants_with_attr);
+    let protocol_enum_from_impls =
+        generate_protocol_enum_from_impls(enum_name, &variants_with_attr);
 
     // Generate type aliases if requested
     let type_aliases = if let Some(suffix) = args.alias_suffix {
@@ -349,7 +350,7 @@ pub fn rpc_requests(attr: TokenStream, item: TokenStream) -> TokenStream {
         #(#channel_impls)*
 
         // From implementations for the original enum
-        #original_from_impls
+        #protocol_enum_from_impls
 
         // Type aliases for WithChannels
         #type_aliases

--- a/irpc-derive/src/lib.rs
+++ b/irpc-derive/src/lib.rs
@@ -399,7 +399,7 @@ impl Parse for MacroArgs {
                     if no_rpc {
                         return Err(syn::Error::new(
                             param_name.span(),
-                            format!("rpc_feature is incompatible with no_rpc"),
+                            "rpc_feature is incompatible with no_rpc",
                         ));
                     }
                     let lit: LitStr = input.parse()?;
@@ -407,12 +407,10 @@ impl Parse for MacroArgs {
                 }
                 "no_rpc" => {
                     if rpc_feature.is_some() {
-                        if no_rpc {
-                            return Err(syn::Error::new(
-                                param_name.span(),
-                                format!("rpc_feature is incompatible with no_rpc"),
-                            ));
-                        }
+                        return Err(syn::Error::new(
+                            param_name.span(),
+                            "rpc_feature is incompatible with no_rpc",
+                        ));
                     }
                     no_rpc = true;
                 }

--- a/irpc-derive/src/lib.rs
+++ b/irpc-derive/src/lib.rs
@@ -304,14 +304,14 @@ pub fn rpc_requests(attr: TokenStream, item: TokenStream) -> TokenStream {
 
         // Generate parent_span method
         let parent_span_impl = if !args.no_spans {
-            generate_parent_span_impl(&message_enum_name, &variant_names)
+            generate_parent_span_impl(message_enum_name, &variant_names)
         } else {
             quote! {}
         };
 
         // Generate From implementations for the message enum (only for variants with rpc attributes)
         let message_from_impls =
-            generate_message_enum_from_impls(&message_enum_name, &variants_with_attr, enum_name);
+            generate_message_enum_from_impls(message_enum_name, &variants_with_attr, enum_name);
 
         let service_impl = quote! {
             impl ::irpc::Service for #enum_name {
@@ -321,7 +321,7 @@ pub fn rpc_requests(attr: TokenStream, item: TokenStream) -> TokenStream {
 
         let remote_service_impl = if !args.no_rpc {
             let block =
-                generate_remote_service_impl(&message_enum_name, enum_name, &variants_with_attr);
+                generate_remote_service_impl(message_enum_name, enum_name, &variants_with_attr);
             quote! {
                 #cfg_feature_rpc
                 #block

--- a/irpc-derive/src/lib.rs
+++ b/irpc-derive/src/lib.rs
@@ -309,7 +309,7 @@ pub fn rpc_requests(attr: TokenStream, item: TokenStream) -> TokenStream {
                 Err(e) => return e.to_compile_error().into(),
             };
 
-            match generate_channels_impl(args, &service_name, request_type, attr.span()) {
+            match generate_channels_impl(args, service_name, request_type, attr.span()) {
                 Ok(impls) => channel_impls.push(impls),
                 Err(e) => return e.to_compile_error().into(),
             }
@@ -322,7 +322,7 @@ pub fn rpc_requests(attr: TokenStream, item: TokenStream) -> TokenStream {
     // Generate type aliases if requested
     let type_aliases = if let Some(suffix) = alias_suffix {
         // Use all variants for type aliases, not just those with rpc attributes
-        generate_type_aliases(&all_variants, &service_name, &suffix)
+        generate_type_aliases(&all_variants, service_name, &suffix)
     } else {
         quote! {}
     };
@@ -358,11 +358,11 @@ pub fn rpc_requests(attr: TokenStream, item: TokenStream) -> TokenStream {
         let message_from_impls = generate_message_enum_from_impls(
             &message_enum_name,
             &variants_with_attr,
-            &service_name,
+            service_name,
         );
 
         let message_from_quic_streams =
-            generate_message_from_wire_impl(&message_enum_name, &enum_name, &variants_with_attr);
+            generate_message_from_wire_impl(&message_enum_name, enum_name, &variants_with_attr);
 
         quote! {
             #message_enum

--- a/irpc-iroh/examples/auth.rs
+++ b/irpc-iroh/examples/auth.rs
@@ -108,7 +108,7 @@ mod storage {
 
     // Use the macro to generate both the StorageProtocol and StorageMessage enums
     // plus implement Channels for each type
-    #[rpc_requests(StorageMessage)]
+    #[rpc_requests(message = StorageMessage)]
     #[derive(Serialize, Deserialize, Debug)]
     enum StorageProtocol {
         #[rpc(tx=oneshot::Sender<Result<(), String>>)]

--- a/irpc-iroh/examples/auth.rs
+++ b/irpc-iroh/examples/auth.rs
@@ -74,7 +74,7 @@ mod storage {
     };
     use irpc::{
         channel::{mpsc, oneshot},
-        Client, Service, WithChannels,
+        Client, WithChannels,
     };
     // Import the macro
     use irpc_derive::rpc_requests;
@@ -83,12 +83,6 @@ mod storage {
     use tracing::info;
 
     const ALPN: &[u8] = b"storage-api/0";
-
-    /// A simple storage service, just to try it out
-    #[derive(Debug, Clone, Copy)]
-    struct StorageService;
-
-    impl Service for StorageService {}
 
     #[derive(Debug, Serialize, Deserialize)]
     struct Auth {
@@ -114,8 +108,8 @@ mod storage {
 
     // Use the macro to generate both the StorageProtocol and StorageMessage enums
     // plus implement Channels for each type
-    #[rpc_requests(StorageService, message = StorageMessage)]
-    #[derive(Serialize, Deserialize)]
+    #[rpc_requests(StorageMessage)]
+    #[derive(Serialize, Deserialize, Debug)]
     enum StorageProtocol {
         #[rpc(tx=oneshot::Sender<Result<(), String>>)]
         Auth(Auth),
@@ -226,7 +220,7 @@ mod storage {
     }
 
     pub struct StorageClient {
-        inner: Client<StorageMessage, StorageProtocol, StorageService>,
+        inner: Client<StorageProtocol>,
     }
 
     impl StorageClient {

--- a/irpc-iroh/examples/auth.rs
+++ b/irpc-iroh/examples/auth.rs
@@ -132,7 +132,7 @@ mod storage {
     impl ProtocolHandler for StorageServer {
         async fn accept(&self, conn: Connection) -> Result<(), AcceptError> {
             let mut authed = false;
-            while let Some(msg) = read_request(&conn).await? {
+            while let Some(msg) = read_request::<StorageProtocol>(&conn).await? {
                 match msg {
                     StorageMessage::Auth(msg) => {
                         let WithChannels { inner, tx, .. } = msg;

--- a/irpc-iroh/examples/derive.rs
+++ b/irpc-iroh/examples/derive.rs
@@ -170,7 +170,7 @@ mod storage {
                 .inner
                 .as_local()
                 .context("can not listen on remote service")?;
-            Ok(IrohProtocol::new(StorageProtocol::forwarding_handler(
+            Ok(IrohProtocol::new(StorageProtocol::remote_handler(
                 local,
             )))
         }

--- a/irpc-iroh/examples/derive.rs
+++ b/irpc-iroh/examples/derive.rs
@@ -63,7 +63,7 @@ mod storage {
     use irpc::{
         channel::{mpsc, oneshot},
         rpc::RemoteService,
-        rpc_requests, Client, LocalSender, WithChannels,
+        rpc_requests, Client, WithChannels,
     };
     // Import the macro
     use irpc_iroh::{IrohProtocol, IrohRemoteConnection};
@@ -110,9 +110,8 @@ mod storage {
                 state: BTreeMap::new(),
             };
             n0_future::task::spawn(actor.run());
-            let local = LocalSender::<StorageProtocol>::from(tx);
             StorageApi {
-                inner: local.into(),
+                inner: Client::local(tx),
             }
         }
 
@@ -169,7 +168,7 @@ mod storage {
         pub fn expose(&self) -> Result<impl ProtocolHandler> {
             let local = self
                 .inner
-                .local()
+                .as_local()
                 .context("can not listen on remote service")?;
             Ok(IrohProtocol::new(StorageProtocol::forwarding_handler(
                 local,

--- a/irpc-iroh/examples/derive.rs
+++ b/irpc-iroh/examples/derive.rs
@@ -62,7 +62,7 @@ mod storage {
     use iroh::{protocol::ProtocolHandler, Endpoint};
     use irpc::{
         channel::{mpsc, oneshot},
-        rpc::MessageWithChannels,
+        rpc::RemoteService,
         rpc_requests, Client, LocalSender, WithChannels,
     };
     // Import the macro
@@ -171,7 +171,9 @@ mod storage {
                 .inner
                 .local()
                 .context("can not listen on remote service")?;
-            Ok(IrohProtocol::new(StorageMessage::forwarding_handler(local)))
+            Ok(IrohProtocol::new(StorageProtocol::forwarding_handler(
+                local,
+            )))
         }
 
         pub async fn get(&self, key: String) -> irpc::Result<Option<String>> {

--- a/irpc-iroh/examples/derive.rs
+++ b/irpc-iroh/examples/derive.rs
@@ -86,7 +86,7 @@ mod storage {
 
     // Use the macro to generate both the StorageProtocol and StorageMessage enums
     // plus implement Channels for each type
-    #[rpc_requests(StorageMessage)]
+    #[rpc_requests(message = StorageMessage)]
     #[derive(Serialize, Deserialize, Debug)]
     enum StorageProtocol {
         #[rpc(tx=oneshot::Sender<Option<String>>)]
@@ -170,9 +170,7 @@ mod storage {
                 .inner
                 .as_local()
                 .context("can not listen on remote service")?;
-            Ok(IrohProtocol::new(StorageProtocol::remote_handler(
-                local,
-            )))
+            Ok(IrohProtocol::new(StorageProtocol::remote_handler(local)))
         }
 
         pub async fn get(&self, key: String) -> irpc::Result<Option<String>> {

--- a/irpc-iroh/src/lib.rs
+++ b/irpc-iroh/src/lib.rs
@@ -10,7 +10,7 @@ use iroh::{
 use irpc::{
     channel::RecvError,
     rpc::{
-        Handler, MessageWithChannels, RemoteConnection, ERROR_CODE_MAX_MESSAGE_SIZE_EXCEEDED,
+        Handler, RemoteConnection, RemoteService, ERROR_CODE_MAX_MESSAGE_SIZE_EXCEEDED,
         MAX_MESSAGE_SIZE,
     },
     util::AsyncReadVarintExt,
@@ -142,13 +142,13 @@ pub async fn handle_connection<R: DeserializeOwned + 'static>(
     }
 }
 
-pub async fn read_request<M: MessageWithChannels>(
+pub async fn read_request<S: RemoteService>(
     connection: &Connection,
-) -> std::io::Result<Option<M>> {
+) -> std::io::Result<Option<S::Message>> {
     Ok(
-        match read_request_raw::<M::WireMessage>(connection).await? {
+        match read_request_raw::<S::WireMessage>(connection).await? {
             None => None,
-            Some((msg, rx, tx)) => Some(M::from_wire(msg, rx, tx)),
+            Some((msg, rx, tx)) => Some(S::from_wire(msg, rx, tx)),
         },
     )
 }

--- a/irpc-iroh/src/lib.rs
+++ b/irpc-iroh/src/lib.rs
@@ -147,7 +147,7 @@ pub async fn read_request<S: RemoteService>(
 ) -> std::io::Result<Option<S::Message>> {
     Ok(read_request_raw::<S::WireMessage>(connection)
         .await?
-        .map(|(msg, rx, tx)| S::from_wire(msg, rx, tx)))
+        .map(|(msg, rx, tx)| S::with_channels(msg, rx, tx)))
 }
 
 /// Reads a single request from the connection.

--- a/irpc-iroh/src/lib.rs
+++ b/irpc-iroh/src/lib.rs
@@ -145,9 +145,9 @@ pub async fn handle_connection<R: DeserializeOwned + 'static>(
 pub async fn read_request<S: RemoteService>(
     connection: &Connection,
 ) -> std::io::Result<Option<S::Message>> {
-    Ok(
-        read_request_raw::<S::WireMessage>(connection).await?.map(|(msg, rx, tx)| S::from_wire(msg, rx, tx)),
-    )
+    Ok(read_request_raw::<S::WireMessage>(connection)
+        .await?
+        .map(|(msg, rx, tx)| S::from_wire(msg, rx, tx)))
 }
 
 /// Reads a single request from the connection.

--- a/irpc-iroh/src/lib.rs
+++ b/irpc-iroh/src/lib.rs
@@ -146,10 +146,7 @@ pub async fn read_request<S: RemoteService>(
     connection: &Connection,
 ) -> std::io::Result<Option<S::Message>> {
     Ok(
-        match read_request_raw::<S::WireMessage>(connection).await? {
-            None => None,
-            Some((msg, rx, tx)) => Some(S::from_wire(msg, rx, tx)),
-        },
+        read_request_raw::<S::WireMessage>(connection).await?.map(|(msg, rx, tx)| S::from_wire(msg, rx, tx)),
     )
 }
 

--- a/irpc-iroh/src/lib.rs
+++ b/irpc-iroh/src/lib.rs
@@ -145,9 +145,9 @@ pub async fn handle_connection<R: DeserializeOwned + 'static>(
 pub async fn read_request<S: RemoteService>(
     connection: &Connection,
 ) -> std::io::Result<Option<S::Message>> {
-    Ok(read_request_raw::<S::WireMessage>(connection)
+    Ok(read_request_raw::<S>(connection)
         .await?
-        .map(|(msg, rx, tx)| S::with_channels(msg, rx, tx)))
+        .map(|(msg, rx, tx)| S::with_remote_channels(msg, rx, tx)))
 }
 
 /// Reads a single request from the connection.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,10 +143,10 @@ use std::{fmt::Debug, future::Future, io, marker::PhantomData, ops::Deref, resul
 /// The `rpc` attribute contains a key-value list with these arguments:
 ///
 /// * `tx = SomeType` *(required)*: Set the kind of channel for sending responses from the server to the client.
-///    Must be a `Sender` type from the [`crate::channel`] module.
+///   Must be a `Sender` type from the [`crate::channel`] module.
 /// * `rx = OtherType` *(optional)*: Set the kind of channel for receiving updates from the client at the server.
-///    Must be a `Receiver` type from the [`crate::channel`] module. If `rx` is not set,
-///    it defaults to [`crate::channel::none::NoReceiver`].
+///   Must be a `Receiver` type from the [`crate::channel`] module. If `rx` is not set,
+///   it defaults to [`crate::channel::none::NoReceiver`].
 ///
 /// ## Examples
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1142,6 +1142,9 @@ pub mod rpc {
         LocalSender, RequestError, RpcMessage, Service,
     };
 
+    /// This is used by irpc-derive to refer to quinn types (SendStream and RecvStream)
+    /// to make generated code work for users without having to depend on quinn directly
+    /// (i.e. when using iroh).
     #[doc(hidden)]
     pub use quinn;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,9 +155,9 @@ use std::{fmt::Debug, future::Future, io, marker::PhantomData, ops::Deref, resul
 /// #[rpc_requests(message = ComputeMessage, alias = "Msg")]
 /// enum ComputeProtocol {
 ///     #[rpc(tx=oneshot::Sender<u128>)]
-///     Sqr(Sqr), // Generates type SqrMsg = WithChannels<Sqr, ComputeService>
+///     Sqr(Sqr), // Generates type SqrMsg = WithChannels<Sqr, ComputeProtocol>
 ///     #[rpc(tx=mpsc::Sender<i64>)]
-///     Sum(Sum), // Generates type SumMsg = WithChannels<Sum, ComputeService>
+///     Sum(Sum), // Generates type SumMsg = WithChannels<Sum, ComputeProtocol>
 /// }
 /// ```
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1137,13 +1137,13 @@ pub mod rpc {
     };
 
     /// Default max message size (16 MiB).
-    const MAX_MESSAGE_SIZE: u64 = 1024 * 1024 * 16;
+    pub const MAX_MESSAGE_SIZE: u64 = 1024 * 1024 * 16;
 
     /// Error code on streams if the max message size was exceeded.
-    const ERROR_CODE_MAX_MESSAGE_SIZE_EXCEEDED: u32 = 1;
+    pub const ERROR_CODE_MAX_MESSAGE_SIZE_EXCEEDED: u32 = 1;
 
     /// Error code on streams if the sender tried to send an message that could not be postcard serialized.
-    const ERROR_CODE_INVALID_POSTCARD: u32 = 2;
+    pub const ERROR_CODE_INVALID_POSTCARD: u32 = 2;
 
     /// Error that can occur when writing the initial message when doing a
     /// cross-process RPC.
@@ -1621,38 +1621,70 @@ pub mod rpc {
                         return io::Result::Ok(());
                     }
                 };
-                loop {
-                    let (send, mut recv) = match connection.accept_bi().await {
-                        Ok((s, r)) => (s, r),
-                        Err(ConnectionError::ApplicationClosed(cause))
-                            if cause.error_code.into_inner() == 0 =>
-                        {
-                            trace!("remote side closed connection {cause:?}");
-                            return Ok(());
-                        }
-                        Err(cause) => {
-                            warn!("failed to accept bi stream {cause:?}");
-                            return Err(cause.into());
-                        }
-                    };
-                    let size = recv.read_varint_u64().await?.ok_or_else(|| {
-                        io::Error::new(io::ErrorKind::UnexpectedEof, "failed to read size")
-                    })?;
-                    let mut buf = vec![0; size as usize];
-                    recv.read_exact(&mut buf)
-                        .await
-                        .map_err(|e| io::Error::new(io::ErrorKind::UnexpectedEof, e))?;
-                    let msg: R = postcard::from_bytes(&buf)
-                        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-                    let rx = recv;
-                    let tx = send;
-                    handler(msg, rx, tx).await?;
-                }
+                handle_connection(connection, handler).await
             };
             let span = trace_span!("rpc", id = request_id);
             tasks.spawn(fut.instrument(span));
             request_id += 1;
         }
+    }
+
+    /// Handles a quic iroh connection with the provided `handler`.
+    pub async fn handle_connection<R: DeserializeOwned + 'static>(
+        connection: quinn::Connection,
+        handler: Handler<R>,
+    ) -> io::Result<()> {
+        loop {
+            let Some((msg, rx, tx)) = read_request(&connection).await? else {
+                return Ok(());
+            };
+            handler(msg, rx, tx).await?;
+        }
+    }
+
+    /// Reads a single request from the connection.
+    ///
+    /// This accepts a bi-directional stream from the connection and reads and parses the request.
+    ///
+    /// Returns the parsed request and the stream pair if reading and parsing the request succeeded.
+    /// Returns None if the remote closed the connection with error code `0`.
+    /// Returns an error for all other failure cases.
+    pub async fn read_request<R: DeserializeOwned + 'static>(
+        connection: &quinn::Connection,
+    ) -> std::io::Result<Option<(R, quinn::RecvStream, quinn::SendStream)>> {
+        let (send, mut recv) = match connection.accept_bi().await {
+            Ok((s, r)) => (s, r),
+            Err(ConnectionError::ApplicationClosed(cause))
+                if cause.error_code.into_inner() == 0 =>
+            {
+                trace!("remote side closed connection {cause:?}");
+                return Ok(None);
+            }
+            Err(cause) => {
+                warn!("failed to accept bi stream {cause:?}");
+                return Err(cause.into());
+            }
+        };
+        let size = recv
+            .read_varint_u64()
+            .await?
+            .ok_or_else(|| io::Error::new(io::ErrorKind::UnexpectedEof, "failed to read size"))?;
+        if size > MAX_MESSAGE_SIZE {
+            connection.close(
+                ERROR_CODE_MAX_MESSAGE_SIZE_EXCEEDED.into(),
+                b"request exceeded max message size",
+            );
+            return Err(RecvError::MaxMessageSizeExceeded.into());
+        }
+        let mut buf = vec![0; size as usize];
+        recv.read_exact(&mut buf)
+            .await
+            .map_err(|e| io::Error::new(io::ErrorKind::UnexpectedEof, e))?;
+        let msg: R = postcard::from_bytes(&buf)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        let rx = recv;
+        let tx = send;
+        Ok(Some((msg, rx, tx)))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1110,7 +1110,7 @@ impl<S: Service> From<tokio::sync::mpsc::Sender<S::Message>> for LocalSender<S> 
 
 #[cfg(not(feature = "rpc"))]
 pub mod rpc {
-    pub struct RemoteSender<S>(std::marker::PhantomData<(R, S)>);
+    pub struct RemoteSender<S>(std::marker::PhantomData<S>);
 }
 
 #[cfg(feature = "rpc")]
@@ -1664,10 +1664,7 @@ pub mod rpc {
         connection: &quinn::Connection,
     ) -> std::io::Result<Option<S::Message>> {
         Ok(
-            match read_request_raw::<S::WireMessage>(connection).await? {
-                None => None,
-                Some((msg, rx, tx)) => Some(S::from_wire(msg, rx, tx)),
-            },
+            read_request_raw::<S::WireMessage>(connection).await?.map(|(msg, rx, tx)| S::from_wire(msg, rx, tx)),
         )
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,16 +139,16 @@ use std::{fmt::Debug, future::Future, io, marker::PhantomData, ops::Deref, resul
 ///
 /// ## Variant attributes
 ///
-/// Individual enum variants can be annotated with the `#[rpc(...)]` attribute to specify channel types.
-/// The types should be one of the `Sender` or `Receiver` types from the [`crate::channel`] module.
+/// Individual enum variants are annotated with the `#[rpc(...)]` attribute to specify channel types.
+/// The `rpc` attribute contains a key-value list with these arguments:
 ///
-/// * `#[rpc(tx=SomeType)]`: Specify the transmitter/sender channel type (required)
-/// * `#[rpc(tx=SomeType, rx=OtherType)]`: Also specify a receiver channel type (optional)
-///
-/// If `rx` is not specified, it defaults to `NoReceiver`.
+/// * `tx = SomeType` *(required)*: Set the kind of channel for sending responses from the server to the client.
+///    Must be a `Sender` type from the [`crate::channel`] module.
+/// * `rx = OtherType` *(optional)*: Set the kind of channel for receiving updates from the client at the server.
+///    Must be a `Receiver` type from the [`crate::channel`] module. If `rx` is not set,
+///    it defaults to [`crate::channel::none::NoReceiver`].
 ///
 /// ## Examples
-///
 ///
 /// With type aliases:
 /// ```no_compile

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,10 +97,10 @@ use std::{fmt::Debug, future::Future, io, marker::PhantomData, ops::Deref, resul
 ///     * Generates a [`RemoteService`] implementation for the protocol enum.
 /// * `alias = "<suffix>"` *(optional)*: Generate type aliases with the given suffix for each [`WithChannels<T, Service>`].
 /// * `rpc_feature = "<feature>"` *(optional)*: If set, the [`RemoteService`] implementation will be feature-flagged
-///    with this feature. Set this if your crate only optionally enables the `rpc` feature
-///    of [`irpc`].
+///   with this feature. Set this if your crate only optionally enables the `rpc` feature
+///   of [`irpc`].
 /// * `no_rpc` *(optional, no value)*: If set, no implementation of [`RemoteService`] will be generated and the generated
-///    code works without the `rpc` feature of `irpc`.
+///   code works without the `rpc` feature of `irpc`.
 /// * `no_spans` *(optional, no value)*: If set, the generated code works without the `spans` feature of `irpc`.
 ///
 /// # Variant Attributes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1612,6 +1612,8 @@ pub mod rpc {
             rx: quinn::RecvStream,
             tx: quinn::SendStream,
         ) -> Self::Message;
+
+        /// Creates a [`Handler`] that forwards all messages to a [`LocalSender`].
         fn forwarding_handler(local_sender: LocalSender<Self>) -> Handler<Self::WireMessage> {
             Arc::new(move |msg, rx, tx| {
                 let msg = Self::from_wire(msg, rx, tx);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1134,7 +1134,7 @@ pub mod rpc {
             oneshot, RecvError, SendError,
         },
         util::{now_or_never, AsyncReadVarintExt, WriteVarintExt},
-        LocalSender, RequestError, RpcMessage, Service, WithChannels,
+        LocalSender, RequestError, RpcMessage, Service,
     };
 
     /// This is used by irpc-derive to refer to quinn types (SendStream and RecvStream)

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "rpc")]
+#![cfg(feature = "quinn_endpoint_setup")]
 
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "rpc")]
+
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 
 use irpc::util::{make_client_endpoint, make_server_endpoint};

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -36,7 +36,7 @@ fn derive_simple() {
     #[derive(Debug, Serialize, Deserialize)]
     struct Response4;
 
-    #[rpc_requests(RequestWithChannels)]
+    #[rpc_requests(message = RequestWithChannels)]
     #[derive(Debug, Serialize, Deserialize)]
     enum Request {
         #[rpc(tx=oneshot::Sender<()>)]

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -36,7 +36,7 @@ fn derive_simple() {
     #[derive(Debug, Serialize, Deserialize)]
     struct Response4;
 
-    #[rpc_requests(Service, message = RequestWithChannels)]
+    #[rpc_requests(RequestWithChannels)]
     #[derive(Debug, Serialize, Deserialize)]
     enum Request {
         #[rpc(tx=oneshot::Sender<()>)]
@@ -48,11 +48,6 @@ fn derive_simple() {
         #[rpc(tx=NoSender)]
         ClientStreaming(ClientStreamingRequest),
     }
-
-    #[derive(Debug, Clone)]
-    struct Service;
-
-    impl irpc::Service for Service {}
 }
 
 /// Use

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "derive")]
+
 use irpc::{
     channel::{none::NoSender, oneshot},
     rpc_requests,
@@ -36,7 +38,7 @@ fn derive_simple() {
     #[derive(Debug, Serialize, Deserialize)]
     struct Response4;
 
-    #[rpc_requests(message = RequestWithChannels)]
+    #[rpc_requests(message = RequestWithChannels, no_rpc, no_spans)]
     #[derive(Debug, Serialize, Deserialize)]
     enum Request {
         #[rpc(tx=oneshot::Sender<()>)]

--- a/tests/mpsc_channel.rs
+++ b/tests/mpsc_channel.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "rpc")]
+#![cfg(feature = "quinn_endpoint_setup")]
 
 use std::{
     io::{self, ErrorKind},

--- a/tests/mpsc_channel.rs
+++ b/tests/mpsc_channel.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "rpc")]
+
 use std::{
     io::{self, ErrorKind},
     time::Duration,

--- a/tests/oneshot_channel.rs
+++ b/tests/oneshot_channel.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "rpc")]
+
 use std::io::{self, ErrorKind};
 
 use irpc::{

--- a/tests/oneshot_channel.rs
+++ b/tests/oneshot_channel.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "rpc")]
+#![cfg(feature = "quinn_endpoint_setup")]
 
 use std::io::{self, ErrorKind};
 


### PR DESCRIPTION
Based on #47 (can rebase on main if needed)
Alternative to #41 
Fixes #39 

This PR simplifies working with `irpc`:

* Instead of defining a separate `FooService` struct, the `Service` trait is implemented on the protocol enum. One type less to create.

* Added an associated types to the `Service` trait to point to the extended message enum (the one where the variants contain the `WithChannels` structs). By doing this, we can reduce the generics on the `Client`  from 3 to 1, and on the `LocalSender` from 2 to 1. I think this is a net benefit for all users.

* The service trait is now implemented by the proc macro if the `message` argument is provided.

* A new trait `RemoteService: Service` has a required method to create a a`Service::Message` from the protocol enum, and a provided method to create a `Handler` for use with the listen function. The `RemoteService` impl is generated by the proc macro. This saves the tedious manual impl of mapping from `msg, rx, tx` to the message enum (see the diff in the examples).

* Added `no_rpc` and `no_spans` arguments to the macro to omit generating code that depends on the `rpc` or `spans` features of `irpc`

* Expanded and improved the documentation of the `rpc_requests` macro. Also moved it from `irpc_derive` to `irpc` to be able to add doc links to items from `irpc`.

First and foremost, have a look at the diff to the examples.