### PR TITLE
refactor: add handle_connection and read_request in rpc module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1137,13 +1137,13 @@ pub mod rpc {
     };
 
     /// Default max message size (16 MiB).
-    const MAX_MESSAGE_SIZE: u64 = 1024 * 1024 * 16;
+    pub const MAX_MESSAGE_SIZE: u64 = 1024 * 1024 * 16;
 
     /// Error code on streams if the max message size was exceeded.
-    const ERROR_CODE_MAX_MESSAGE_SIZE_EXCEEDED: u32 = 1;
+    pub const ERROR_CODE_MAX_MESSAGE_SIZE_EXCEEDED: u32 = 1;
 
     /// Error code on streams if the sender tried to send an message that could not be postcard serialized.
-    const ERROR_CODE_INVALID_POSTCARD: u32 = 2;
+    pub const ERROR_CODE_INVALID_POSTCARD: u32 = 2;
 
     /// Error that can occur when writing the initial message when doing a
     /// cross-process RPC.
@@ -1621,38 +1621,70 @@ pub mod rpc {
                         return io::Result::Ok(());
                     }
                 };
-                loop {
-                    let (send, mut recv) = match connection.accept_bi().await {
-                        Ok((s, r)) => (s, r),
-                        Err(ConnectionError::ApplicationClosed(cause))
-                            if cause.error_code.into_inner() == 0 =>
-                        {
-                            trace!("remote side closed connection {cause:?}");
-                            return Ok(());
-                        }
-                        Err(cause) => {
-                            warn!("failed to accept bi stream {cause:?}");
-                            return Err(cause.into());
-                        }
-                    };
-                    let size = recv.read_varint_u64().await?.ok_or_else(|| {
-                        io::Error::new(io::ErrorKind::UnexpectedEof, "failed to read size")
-                    })?;
-                    let mut buf = vec![0; size as usize];
-                    recv.read_exact(&mut buf)
-                        .await
-                        .map_err(|e| io::Error::new(io::ErrorKind::UnexpectedEof, e))?;
-                    let msg: R = postcard::from_bytes(&buf)
-                        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-                    let rx = recv;
-                    let tx = send;
-                    handler(msg, rx, tx).await?;
-                }
+                handle_connection(connection, handler).await
             };
             let span = trace_span!("rpc", id = request_id);
             tasks.spawn(fut.instrument(span));
             request_id += 1;
         }
+    }
+
+    /// Handles a quic iroh connection with the provided `handler`.
+    pub async fn handle_connection<R: DeserializeOwned + 'static>(
+        connection: quinn::Connection,
+        handler: Handler<R>,
+    ) -> io::Result<()> {
+        loop {
+            let Some((msg, rx, tx)) = read_request(&connection).await? else {
+                return Ok(());
+            };
+            handler(msg, rx, tx).await?;
+        }
+    }
+
+    /// Reads a single request from the connection.
+    ///
+    /// This accepts a bi-directional stream from the connection and reads and parses the request.
+    ///
+    /// Returns the parsed request and the stream pair if reading and parsing the request succeeded.
+    /// Returns None if the remote closed the connection with error code `0`.
+    /// Returns an error for all other failure cases.
+    pub async fn read_request<R: DeserializeOwned + 'static>(
+        connection: &quinn::Connection,
+    ) -> std::io::Result<Option<(R, quinn::RecvStream, quinn::SendStream)>> {
+        let (send, mut recv) = match connection.accept_bi().await {
+            Ok((s, r)) => (s, r),
+            Err(ConnectionError::ApplicationClosed(cause))
+                if cause.error_code.into_inner() == 0 =>
+            {
+                trace!("remote side closed connection {cause:?}");
+                return Ok(None);
+            }
+            Err(cause) => {
+                warn!("failed to accept bi stream {cause:?}");
+                return Err(cause.into());
+            }
+        };
+        let size = recv
+            .read_varint_u64()
+            .await?
+            .ok_or_else(|| io::Error::new(io::ErrorKind::UnexpectedEof, "failed to read size"))?;
+        if size > MAX_MESSAGE_SIZE {
+            connection.close(
+                ERROR_CODE_MAX_MESSAGE_SIZE_EXCEEDED.into(),
+                b"request exceeded max message size",
+            );
+            return Err(RecvError::MaxMessageSizeExceeded.into());
+        }
+        let mut buf = vec![0; size as usize];
+        recv.read_exact(&mut buf)
+            .await
+            .map_err(|e| io::Error::new(io::ErrorKind::UnexpectedEof, e))?;
+        let msg: R = postcard::from_bytes(&buf)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        let rx = recv;
+        let tx = send;
+        Ok(Some((msg, rx, tx)))
     }
 }
 


### PR DESCRIPTION
This aligns the non-iroh quinn rpc to the structure added in https://github.com/n0-computer/irpc/pull/14.
This is useful if the high-level `listen` function is not what you need, but still don't want to write it all yourself.

Also adds a check to respect the MAX_MESSAGE_SIZE for request messages as well (previously those were not checked).