### PR TITLE
feat: variant feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ quinn_endpoint_setup = ["rpc", "dep:rustls", "dep:rcgen", "dep:anyhow", "dep:fut
 spans = ["dep:tracing"]
 stream = ["dep:futures-util"]
 derive = ["dep:irpc-derive"]
+varint-util = ["dep:postcard", "dep:smallvec", "tokio/io-util"]
 default = ["rpc", "quinn_endpoint_setup", "spans", "stream", "derive"]
 
 [[example]]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,11 +175,7 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use self::channel::none::NoReceiver;
 
-#[cfg(feature = "rpc")]
-#[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "rpc")))]
 pub mod util;
-#[cfg(not(feature = "rpc"))]
-mod util;
 
 /// Requirements for a RPC message
 ///
@@ -1172,6 +1168,10 @@ pub enum RequestError {
     #[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "rpc")))]
     #[error("error opening stream: {0}")]
     Other(#[from] anyhow::Error),
+
+    #[cfg(not(feature = "rpc"))]
+    #[error("(Without the rpc feature, requests cannot fail")]
+    Unreachable,
 }
 
 /// Error type that subsumes all possible errors in this crate, for convenience.
@@ -1212,6 +1212,8 @@ impl From<RequestError> for io::Error {
             RequestError::Connection(e) => e.into(),
             #[cfg(feature = "rpc")]
             RequestError::Other(e) => io::Error::other(e),
+            #[cfg(not(feature = "rpc"))]
+            RequestError::Unreachable => unreachable!(),
         }
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -167,7 +167,7 @@ mod quinn_setup_utils {
 #[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "quinn_endpoint_setup")))]
 pub use quinn_setup_utils::*;
 
-#[cfg(feature = "rpc")]
+#[cfg(any(feature = "rpc", feature = "varint-util"))]
 mod varint_util {
     use std::{
         future::Future,
@@ -375,7 +375,8 @@ mod varint_util {
         }
     }
 }
-#[cfg(feature = "rpc")]
+
+#[cfg(any(feature = "rpc", feature = "varint-util"))]
 pub use varint_util::{AsyncReadVarintExt, AsyncWriteVarintExt, WriteVarintExt};
 
 mod fuse_wrapper {


### PR DESCRIPTION
* iroh-blobs uses the varint utils. Currently they are behind the `rpc` feature. However iroh-blobs would use those even when the quinn rpc is disabled. So I added a feature flag for this. Maybe the better thing would be to move those out into a varint crate? Dunno. But this is fine too.
* Added a `RequestError::Unreachable` variant if `rpc`  feature is disabled. `Snafu` chokes on empty enums somehow. This was the quick fix to have `iroh_blobs` build without irpc's `rpc` feature. Not sure if there is a better way, would need to investigate what exactly snafu does.