### PR TITLE
fix: Also set crypto provider in `configure_client_insecure`

### DIFF
--- a/examples/compute.rs
+++ b/examples/compute.rs
@@ -34,7 +34,7 @@ enum ComputeProtocol {
     Multiply(Multiply),
 }
 
-// Define ComputeRequest sub-messages
+// Define ComputeProtocol sub-messages
 #[derive(Debug, Serialize, Deserialize)]
 struct Sqr {
     num: u64,
@@ -51,15 +51,6 @@ struct Fibonacci {
 #[derive(Debug, Serialize, Deserialize)]
 struct Multiply {
     initial: u64,
-}
-
-// Define ComputeRequest enum
-#[derive(Debug, Serialize, Deserialize)]
-enum ComputeRequest {
-    Sqr(Sqr),
-    Sum(Sum),
-    Fibonacci(Fibonacci),
-    Multiply(Multiply),
 }
 
 // The actor that processes requests

--- a/examples/local.rs
+++ b/examples/local.rs
@@ -15,9 +15,6 @@ struct Get {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-struct List;
-
-#[derive(Debug, Serialize, Deserialize)]
 struct Set {
     key: String,
     value: String,
@@ -28,9 +25,6 @@ impl From<(String, String)> for Set {
         Self { key, value }
     }
 }
-
-#[derive(Debug, Serialize, Deserialize)]
-struct SetMany;
 
 #[rpc_requests(message = StorageMessage, no_rpc, no_spans)]
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -22,13 +22,12 @@ mod quinn_setup_utils {
             certs.add(cert)?;
         }
 
-        let crypto_client_config = rustls::ClientConfig::builder_with_provider(Arc::new(
-            rustls::crypto::ring::default_provider(),
-        ))
-        .with_protocol_versions(&[&rustls::version::TLS13])
-        .expect("valid versions")
-        .with_root_certificates(certs)
-        .with_no_client_auth();
+        let provider = rustls::crypto::ring::default_provider();
+        let crypto_client_config = rustls::ClientConfig::builder_with_provider(Arc::new(provider))
+            .with_protocol_versions(&[&rustls::version::TLS13])
+            .expect("valid versions")
+            .with_root_certificates(certs)
+            .with_no_client_auth();
         let quic_client_config =
             quinn::crypto::rustls::QuicClientConfig::try_from(crypto_client_config)?;
 
@@ -54,7 +53,10 @@ mod quinn_setup_utils {
 
     /// Create a quinn client config and trust all certificates.
     pub fn configure_client_insecure() -> Result<ClientConfig> {
-        let crypto = rustls::ClientConfig::builder()
+        let provider = rustls::crypto::ring::default_provider();
+        let crypto = rustls::ClientConfig::builder_with_provider(Arc::new(provider))
+            .with_protocol_versions(rustls::DEFAULT_VERSIONS)
+            .expect("valid versions")
             .dangerous()
             .with_custom_certificate_verifier(Arc::new(SkipServerVerification))
             .with_no_client_auth();

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -8,6 +8,8 @@ use serde::{Deserialize, Serialize};
 
 #[test]
 fn derive_simple() {
+    #![allow(dead_code)]
+
     #[derive(Debug, Serialize, Deserialize)]
     struct RpcRequest;
 


### PR DESCRIPTION
This fixes a panic for me, when code is using `irpc::util::quinn_setup_util::make_insecure_client_endpoint`, where `configure_client_insecure` wouldn't tell rustls which crypto provider to use.

<details>
<summary>The panic in question</summary>

```
thread 'tokio-runtime-worker' panicked at /home/philipp/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rustls-0.23.31/src/crypto/mod.rs:249:14:

Could not automatically determine the process-level CryptoProvider from Rustls crate features.
Call CryptoProvider::install_default() before this point to select a provider manually, or make sure exactly one of the 'aws-lc-rs' and 'ring' features is enabled.
See the documentation of the CryptoProvider type for more information.
            
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/std/src/panicking.rs:697:5
   1: core::panicking::panic_fmt
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/core/src/panicking.rs:75:14
   2: core::panicking::panic_display
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/core/src/panicking.rs:269:5
   3: core::option::expect_failed
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/core/src/option.rs:2049:5
   4: core::option::Option<T>::expect
             at /home/philipp/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/option.rs:958:21
   5: rustls::crypto::CryptoProvider::get_default_or_install_from_crate_features
             at /home/philipp/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rustls-0.23.31/src/crypto/mod.rs:248:24
   6: rustls::client::client_conn::ClientConfig::builder_with_protocol_versions
             at /home/philipp/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rustls-0.23.31/src/client/client_conn.rs:317:13
   7: rustls::client::client_conn::ClientConfig::builder
             at /home/philipp/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rustls-0.23.31/src/client/client_conn.rs:294:9
   8: irpc::util::quinn_setup_utils::configure_client_insecure
             at /home/philipp/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/irpc-0.7.0/src/util.rs:57:22
   9: irpc::util::quinn_setup_utils::non_wasm::make_insecure_client_endpoint
             at /home/philipp/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/irpc-0.7.0/src/util.rs:93:30
```

</details>

