### PR TITLE
feat: Add new syntax candy fn to send a stream of updates to the server...

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1454,6 +1454,7 @@ impl<S: Service> Client<S> {
         }
     }
 
+    /// Performs a request for which the client can send updates but does not receive a reply from the server.
     pub fn notify_streaming<Req, Update>(
         &self,
         msg: Req,


### PR DESCRIPTION
…without any return message.

Basically a streaming version of notify.

I am using this in my blobs PR that turns provider events into an irpc protocol. See https://github.com/n0-computer/iroh-blobs/pull/142 . In the PR I use an ..Ext trait, but this might as well go into irpc itself.