### PR TITLE
fix: make irpc-iroh compile in wasm, and check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,12 +116,13 @@ jobs:
       - name: Install wasm-tools
         uses: bytecodealliance/actions/wasm-tools/setup@v1
       - name: wasm32 build
-        run: cargo build --target wasm32-unknown-unknown
+        run: cargo build --target wasm32-unknown-unknown --all
       # If the Wasm file contains any 'import "env"' declarations, then
       # some non-Wasm-compatible code made it into the final code.
-      - name: Ensure no 'import "env"' in iroh-relay Wasm
+      - name: Ensure no 'import "env"' in wasm
         run: |
           ! wasm-tools print --skeleton target/wasm32-unknown-unknown/debug/irpc.wasm | grep 'import "env"'
+          ! wasm-tools print --skeleton target/wasm32-unknown-unknown/debug/irpc_iroh.wasm | grep 'import "env"'
 
   # Checks correct runtime deps and features are requested by not including dev-dependencies.
   check-deps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,8 @@ jobs:
   wasm_build:
     name: Build wasm32
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: '--cfg getrandom_backend="wasm_js"'
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ description = "A streaming rpc system based on quic"
 # Sadly this also needs to be updated in .github/workflows/ci.yml
 rust-version = "1.76"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 # we require serde even in non-rpc mode
 serde = { workspace = true }

--- a/irpc-iroh/Cargo.toml
+++ b/irpc-iroh/Cargo.toml
@@ -9,6 +9,9 @@ license = "Apache-2.0/MIT"
 repository = "https://github.com/n0-computer/irpc"
 description = "Iroh transport for irpc"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 anyhow = { workspace = true }
 iroh = { workspace = true }

--- a/irpc-iroh/src/lib.rs
+++ b/irpc-iroh/src/lib.rs
@@ -16,7 +16,7 @@ use irpc::{
     util::AsyncReadVarintExt,
     LocalSender, RequestError,
 };
-use n0_future::{boxed::BoxFuture, TryFutureExt};
+use n0_future::{future::Boxed as BoxFuture, TryFutureExt};
 use serde::de::DeserializeOwned;
 use tracing::{trace, trace_span, warn, Instrument};
 


### PR DESCRIPTION
`irpc-iroh` does not compile to wasm atm because we imported the wrong BoxFuture alias 

(in n0_future there are two: one that has a Send bound always, and one that has one on non-wasm targets and does not have one on wasm targets. We might want to revisit this).

Also we only checked irpc but not irpc-iroh in CI for wasm compilation. Fixed here too.