### PR TITLE
fix: set keepalive, improve listen loops

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
       - uses: swatinem/rust-cache@v2
       - name: cargo fmt
         run: cargo fmt --all -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 # we require serde even in non-rpc mode
 serde = { workspace = true }
-# just for the oneshot and mpsc queues
-tokio = { workspace = true, features = ["sync"] }
+# just for the oneshot and mpsc queues, and tokio::select!
+tokio = { workspace = true, features = ["sync", "macros"] }
 # for PollSender (which for some reason is not available in the main tokio api)
 tokio-util = { version = "0.7.14", default-features = false }
 # errors

--- a/examples/compute.rs
+++ b/examples/compute.rs
@@ -448,7 +448,7 @@ pub async fn reference_bench(n: u64) -> anyhow::Result<()> {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt().init();
+    tracing_subscriber::fmt::init();
     println!("Local use");
     local().await?;
     println!("Remote use");

--- a/examples/storage.rs
+++ b/examples/storage.rs
@@ -228,7 +228,7 @@ async fn remote() -> anyhow::Result<()> {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt().init();
+    tracing_subscriber::fmt::init();
     println!("Local use");
     local().await?;
     println!("Remote use");

--- a/irpc-iroh/examples/derive.rs
+++ b/irpc-iroh/examples/derive.rs
@@ -5,7 +5,7 @@ use self::storage::StorageApi;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    tracing_subscriber::fmt().init();
+    tracing_subscriber::fmt::init();
     println!("Local use");
     local().await?;
     println!("Remote use");

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,7 +5,7 @@
 #[cfg(feature = "quinn_endpoint_setup")]
 #[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "quinn_endpoint_setup")))]
 mod quinn_setup_utils {
-    use std::sync::Arc;
+    use std::{sync::Arc, time::Duration};
 
     use anyhow::Result;
     use quinn::{crypto::rustls::QuicClientConfig, ClientConfig, ServerConfig};
@@ -31,7 +31,11 @@ mod quinn_setup_utils {
         let quic_client_config =
             quinn::crypto::rustls::QuicClientConfig::try_from(crypto_client_config)?;
 
-        Ok(ClientConfig::new(Arc::new(quic_client_config)))
+        let mut transport_config = quinn::TransportConfig::default();
+        transport_config.keep_alive_interval(Some(Duration::from_secs(1)));
+        let mut client_config = ClientConfig::new(Arc::new(quic_client_config));
+        client_config.transport_config(Arc::new(transport_config));
+        Ok(client_config)
     }
 
     /// Create a quinn server config with a self-signed certificate


### PR DESCRIPTION
A couple of fixes for things I noticed recently:

* Set a keepalive interval on the client transport config when using the quinn transport with the helpers from the `util` method. Without this, a connection times out if no rpc calls are issued for 30s (default idle timeout)
* Improve the `listen` helper functions for both `irpc` and `irpc_iroh`:
  * Add remote address to log lines
  * Log errors from `handle_connection`
  * Poll the `JoinSet` for finished tasks, otherwise the result list in the join set grows unbounded over time
 * Fix the `tracing_subscriber` setup call in the examples