### PR TITLE
chore: migrate to rust edition 2024, align formatting with iroh standards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: swatinem/rust-cache@v2
-      - name: cargo fmt
-        run: cargo fmt --all -- --check
+      - uses: taiki-e/install-action@cargo-make
       - name: cargo clippy
         run: cargo clippy --locked --workspace --all-targets --all-features
+      - run: cargo make format-check
 
   test:
     runs-on: ${{ matrix.target.os }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "irpc"
 version = "0.12.0"
-edition = "2021"
+edition = "2024"
 authors = ["Rüdiger Klaehn <rklaehn@protonmail.com>", "n0 team"]
 keywords = ["api", "protocol", "network", "rpc"]
 categories = ["network-programming"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,0 +1,28 @@
+# Use cargo-make to run tasks here: https://crates.io/crates/cargo-make
+
+[tasks.format]
+workspace = false
+command = "cargo"
+args = [
+     "fmt",
+     "--all",
+     "--",
+     "--config",
+     "unstable_features=true",
+     "--config",
+     "imports_granularity=Crate,group_imports=StdExternalCrate,reorder_imports=true,format_code_in_doc_comments=true",
+]
+
+[tasks.format-check]
+workspace = false
+command = "cargo"
+args = [
+     "fmt",
+     "--all",
+     "--check",
+     "--",
+     "--config",
+     "unstable_features=true",
+     "--config",
+     "imports_granularity=Crate,group_imports=StdExternalCrate,reorder_imports=true,format_code_in_doc_comments=true",
+]

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ See the [module docs](https://docs.rs/irpc/latest/irpc/).
 Properly building docs for this crate is quite complex. For all the gory details,
 see [DOCS.md].
 
+# Development
+
+Run `cargo make format` before committing, it will run `cargo fmt` with the arguments expected by this project.
+
 ## License
 
 Copyright 2025 N0, INC.

--- a/examples/compute.rs
+++ b/examples/compute.rs
@@ -6,11 +6,11 @@ use std::{
 use anyhow::bail;
 use futures_buffered::BufferedStreamExt;
 use irpc::{
+    Client, Request, WithChannels,
     channel::{mpsc, oneshot},
-    rpc::{listen, RemoteService},
+    rpc::{RemoteService, listen},
     rpc_requests,
     util::{make_client_endpoint, make_server_endpoint},
-    Client, Request, WithChannels,
 };
 use n0_future::{
     stream::StreamExt,

--- a/examples/derive.rs
+++ b/examples/derive.rs
@@ -5,11 +5,11 @@ use std::{
 
 use anyhow::{Context, Result};
 use irpc::{
+    Client, WithChannels,
     channel::{mpsc, oneshot},
     rpc::RemoteService,
     rpc_requests,
     util::{make_client_endpoint, make_server_endpoint},
-    Client, WithChannels,
 };
 // Import the macro
 use n0_future::task::{self, AbortOnDropHandle};

--- a/examples/local.rs
+++ b/examples/local.rs
@@ -6,7 +6,7 @@
 
 use std::collections::BTreeMap;
 
-use irpc::{channel::oneshot, rpc_requests, Client, WithChannels};
+use irpc::{Client, WithChannels, channel::oneshot, rpc_requests};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/examples/storage.rs
+++ b/examples/storage.rs
@@ -5,10 +5,10 @@ use std::{
 
 use anyhow::bail;
 use irpc::{
-    channel::{mpsc, none::NoReceiver, oneshot},
-    rpc::{listen, RemoteService},
-    util::{make_client_endpoint, make_server_endpoint},
     Channels, Client, Request, Service, WithChannels,
+    channel::{mpsc, none::NoReceiver, oneshot},
+    rpc::{RemoteService, listen},
+    util::{make_client_endpoint, make_server_endpoint},
 };
 use n0_future::task::{self, AbortOnDropHandle};
 use serde::{Deserialize, Serialize};

--- a/irpc-derive/Cargo.toml
+++ b/irpc-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "irpc-derive"
 version = "0.9.0"
-edition = "2021"
+edition = "2024"
 authors = ["Rüdiger Klaehn <rklaehn@protonmail.com>"]
 keywords = ["api", "protocol", "network", "rpc", "macro"]
 categories = ["network-programming"]

--- a/irpc-derive/src/lib.rs
+++ b/irpc-derive/src/lib.rs
@@ -2,14 +2,14 @@ use std::collections::HashSet;
 
 use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
-use quote::{quote, ToTokens};
+use quote::{ToTokens, quote};
 use syn::{
+    Attribute, Data, DeriveInput, Error, Fields, Ident, LitStr, Token, Type, Visibility,
     parse::{Parse, ParseStream},
     parse_macro_input,
     punctuated::Punctuated,
     spanned::Spanned,
     token::Comma,
-    Attribute, Data, DeriveInput, Error, Fields, Ident, LitStr, Token, Type, Visibility,
 };
 
 /// Attribute on protocol enums and variants
@@ -40,7 +40,7 @@ pub fn rpc_requests(attr: TokenStream, item: TokenStream) -> TokenStream {
             return error_tokens(
                 input.span(),
                 "The rpc_requests macro can only be applied to enums",
-            )
+            );
         }
     };
 
@@ -68,18 +68,25 @@ pub fn rpc_requests(attr: TokenStream, item: TokenStream) -> TokenStream {
 
         let request_type = match rpc_attr.wrap {
             None => match &mut variant.fields {
-                Fields::Unnamed(ref mut fields) if fields.unnamed.len() == 1 => {
+                Fields::Unnamed(fields) if fields.unnamed.len() == 1 => {
                     fields.unnamed[0].ty.clone()
                 }
-                _ => return error_tokens(
-                    variant.span(),
-                    "Each variant must either have exactly one unnamed field, or use the `wrap` argument in the `rpc` attribute.",
-                ),
+                _ => {
+                    return error_tokens(
+                        variant.span(),
+                        "Each variant must either have exactly one unnamed field, or use the `wrap` argument in the `rpc` attribute.",
+                    );
+                }
             },
             Some(WrapArgs { ident, derive, vis }) => {
                 let vis = vis.as_ref().unwrap_or(&input.vis).clone();
                 let ty = type_from_ident(&ident);
-                let struc = struct_from_variant_fields(ident, variant.fields.clone(), variant.attrs.clone(), vis);
+                let struc = struct_from_variant_fields(
+                    ident,
+                    variant.fields.clone(),
+                    variant.attrs.clone(),
+                    vis,
+                );
                 wrapper_types.extend(quote! {
                     #[derive(::std::fmt::Debug, ::serde::Serialize, ::serde::Deserialize, #(#derive),* )]
                     #struc
@@ -543,8 +550,8 @@ fn single_unnamed_field(ty: Type) -> Fields {
 
 fn set_fields_vis(fields: &mut Fields, vis: &Visibility) {
     let inner = match fields {
-        Fields::Named(ref mut named) => named.named.iter_mut(),
-        Fields::Unnamed(ref mut unnamed) => unnamed.unnamed.iter_mut(),
+        Fields::Named(named) => named.named.iter_mut(),
+        Fields::Unnamed(unnamed) => unnamed.unnamed.iter_mut(),
         Fields::Unit => return,
     };
     for field in inner {

--- a/irpc-iroh/Cargo.toml
+++ b/irpc-iroh/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "irpc-iroh"
 version = "0.12.0"
-edition = "2021"
+edition = "2024"
 authors = ["Rüdiger Klaehn <rklaehn@protonmail.com>", "n0 team"]
 keywords = ["api", "protocol", "network", "rpc"]
 categories = ["network-programming"]

--- a/irpc-iroh/examples/0rtt.rs
+++ b/irpc-iroh/examples/0rtt.rs
@@ -9,9 +9,9 @@ use std::{
 use anyhow::{Context, Result};
 use clap::Parser;
 use iroh::{
+    Endpoint, EndpointAddr, EndpointId, SecretKey,
     endpoint::{AfterHandshakeOutcome, ConnectionInfo, EndpointHooks},
     protocol::Router,
-    Endpoint, EndpointAddr, EndpointId, SecretKey,
 };
 use ping::EchoApi;
 
@@ -54,7 +54,9 @@ async fn main() -> Result<()> {
             wait_for_ticket,
         } => {
             if !no_0rtt && !wait_for_ticket {
-                eprintln!("0-RTT is enabled but wait_for_ticket is not set. After 2 requests with 0rtt the 0rtt resumption tickets will be consumed and a connection will be done without 0rtt.");
+                eprintln!(
+                    "0-RTT is enabled but wait_for_ticket is not set. After 2 requests with 0rtt the 0rtt resumption tickets will be consumed and a connection will be done without 0rtt."
+                );
             }
             let n = n
                 .iter()
@@ -226,7 +228,7 @@ mod cli {
 mod ping {
     use anyhow::{Context, Result};
     use iroh::Endpoint;
-    use irpc::{channel::oneshot, rpc::RemoteService, rpc_requests, Client, WithChannels};
+    use irpc::{Client, WithChannels, channel::oneshot, rpc::RemoteService, rpc_requests};
     use irpc_iroh::{
         Iroh0RttProtocol, IrohProtocol, IrohRemoteConnection, IrohZrttRemoteConnection,
     };

--- a/irpc-iroh/examples/auth.rs
+++ b/irpc-iroh/examples/auth.rs
@@ -4,7 +4,7 @@
 //! * Authenticating peers
 
 use anyhow::Result;
-use iroh::{protocol::Router, Endpoint};
+use iroh::{Endpoint, protocol::Router};
 
 use self::storage::{StorageClient, StorageServer};
 
@@ -67,16 +67,17 @@ mod storage {
 
     use anyhow::Result;
     use iroh::{
+        Endpoint,
         endpoint::Connection,
         protocol::{AcceptError, ProtocolHandler},
-        Endpoint,
     };
     use irpc::{
+        Client, WithChannels,
         channel::{mpsc, oneshot},
-        rpc_requests, Client, WithChannels,
+        rpc_requests,
     };
     // Import the macro
-    use irpc_iroh::{read_request, IrohLazyRemoteConnection};
+    use irpc_iroh::{IrohLazyRemoteConnection, read_request};
     use serde::{Deserialize, Serialize};
     use tracing::info;
 

--- a/irpc-iroh/examples/remote-and-local.rs
+++ b/irpc-iroh/examples/remote-and-local.rs
@@ -3,7 +3,7 @@
 //! The [`StorageApi`] struct is only defined once and can be used both locally and as a remote client.
 
 use anyhow::Result;
-use iroh::{protocol::Router, Endpoint};
+use iroh::{Endpoint, protocol::Router};
 
 use self::storage::StorageApi;
 
@@ -71,11 +71,12 @@ mod storage {
     use std::{collections::BTreeMap, sync::Arc};
 
     use anyhow::{Context, Result};
-    use iroh::{protocol::ProtocolHandler, Endpoint};
+    use iroh::{Endpoint, protocol::ProtocolHandler};
     use irpc::{
+        Client, WithChannels,
         channel::{mpsc, oneshot},
         rpc::RemoteService,
-        rpc_requests, Client, WithChannels,
+        rpc_requests,
     };
     // Import the macro
     use irpc_iroh::{IrohLazyRemoteConnection, IrohProtocol};

--- a/irpc-iroh/examples/server-actor.rs
+++ b/irpc-iroh/examples/server-actor.rs
@@ -10,8 +10,8 @@ mod proto {
     use std::collections::HashMap;
 
     use anyhow::Result;
-    use iroh::{protocol::Router, Endpoint, EndpointId};
-    use irpc::{channel::oneshot, rpc_requests, Client, WithChannels};
+    use iroh::{Endpoint, EndpointId, protocol::Router};
+    use irpc::{Client, WithChannels, channel::oneshot, rpc_requests};
     use irpc_iroh::IrohProtocol;
     use serde::{Deserialize, Serialize};
 
@@ -90,7 +90,7 @@ mod cli {
     use clap::Parser;
     use iroh::EndpointId;
 
-    use crate::proto::{connect, listen, GetRequest, SetRequest};
+    use crate::proto::{GetRequest, SetRequest, connect, listen};
 
     #[derive(Debug, Parser)]
     enum Cli {

--- a/irpc-iroh/examples/server-shared-state.rs
+++ b/irpc-iroh/examples/server-shared-state.rs
@@ -2,7 +2,7 @@
 //! on the server side instead of with an actor loop.
 
 use anyhow::Result;
-use iroh::{protocol::Router, Endpoint};
+use iroh::{Endpoint, protocol::Router};
 
 use self::storage::{StorageClient, StorageServer};
 
@@ -54,16 +54,17 @@ mod storage {
 
     use anyhow::Result;
     use iroh::{
+        Endpoint,
         endpoint::Connection,
         protocol::{AcceptError, ProtocolHandler},
-        Endpoint,
     };
     use irpc::{
+        Client, WithChannels,
         channel::{mpsc, oneshot},
-        rpc_requests, Client, WithChannels,
+        rpc_requests,
     };
     // Import the macro
-    use irpc_iroh::{read_request, IrohLazyRemoteConnection, IrohRemoteConnection};
+    use irpc_iroh::{IrohLazyRemoteConnection, IrohRemoteConnection, read_request};
     use serde::{Deserialize, Serialize};
     use tracing::info;
 

--- a/irpc-iroh/src/lib.rs
+++ b/irpc-iroh/src/lib.rs
@@ -2,31 +2,31 @@ use std::{
     fmt,
     future::Future,
     io,
-    sync::{atomic::AtomicU64, Arc},
+    sync::{Arc, atomic::AtomicU64},
 };
 
 use iroh::{
+    EndpointId,
     endpoint::{
         Accepting, Connection, ConnectionError, IncomingZeroRttConnection,
         OutgoingZeroRttConnection, RecvStream, RemoteEndpointIdError, SendStream, VarInt,
         ZeroRttStatus,
     },
     protocol::{AcceptError, ProtocolHandler},
-    EndpointId,
 };
 use irpc::{
+    LocalSender, RequestError,
     channel::oneshot,
     rpc::{
-        Handler, RemoteConnection, RemoteService, ERROR_CODE_MAX_MESSAGE_SIZE_EXCEEDED,
-        MAX_MESSAGE_SIZE,
+        ERROR_CODE_MAX_MESSAGE_SIZE_EXCEEDED, Handler, MAX_MESSAGE_SIZE, RemoteConnection,
+        RemoteService,
     },
     util::AsyncReadVarintExt,
-    LocalSender, RequestError,
 };
-use n0_error::{e, Result};
-use n0_future::{future::Boxed as BoxFuture, TryFutureExt};
+use n0_error::{Result, e};
+use n0_future::{TryFutureExt, future::Boxed as BoxFuture};
 use serde::de::DeserializeOwned;
-use tracing::{debug, error_span, trace, trace_span, warn, Instrument};
+use tracing::{Instrument, debug, error_span, trace, trace_span, warn};
 
 /// Returns a client that connects to a irpc service using an [`iroh::Endpoint`].
 pub fn client<S: irpc::Service>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,10 +295,10 @@ use std::{fmt::Debug, future::Future, io, marker::PhantomData, ops::Deref, resul
 #[cfg(feature = "derive")]
 #[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "derive")))]
 pub use irpc_derive::rpc_requests;
-use n0_error::stack_error;
 #[cfg(feature = "rpc")]
 use n0_error::AnyError;
-use serde::{de::DeserializeOwned, Serialize};
+use n0_error::stack_error;
+use serde::{Serialize, de::DeserializeOwned};
 
 use self::{
     channel::{
@@ -1012,11 +1012,10 @@ pub mod channel {
                 value: U,
             ) -> Pin<Box<dyn Future<Output = Result<(), SendError>> + Send + '_>> {
                 Box::pin(async move {
-                    match (self.f)(value) { Some(v) => {
-                        self.sender.send(v).await
-                    } _ => {
-                        Ok(())
-                    }}
+                    match (self.f)(value) {
+                        Some(v) => self.sender.send(v).await,
+                        _ => Ok(()),
+                    }
                 })
             }
 
@@ -1025,11 +1024,10 @@ pub mod channel {
                 value: U,
             ) -> Pin<Box<dyn Future<Output = Result<bool, SendError>> + Send + '_>> {
                 Box::pin(async move {
-                    match (self.f)(value) { Some(v) => {
-                        self.sender.try_send(v).await
-                    } _ => {
-                        Ok(true)
-                    }}
+                    match (self.f)(value) {
+                        Some(v) => self.sender.try_send(v).await,
+                        _ => Ok(true),
+                    }
                 })
             }
 
@@ -1349,7 +1347,9 @@ impl<S: Service> Client<S> {
         &self,
     ) -> impl Future<
         Output = result::Result<Request<LocalSender<S>, rpc::RemoteSender<S>>, RequestError>,
-    > + 'static + use<S> {
+    >
+    + 'static
+    + use<S> {
         #[cfg(feature = "rpc")]
         {
             let cloned = match &self.0 {
@@ -1377,7 +1377,10 @@ impl<S: Service> Client<S> {
     }
 
     /// Performs a request for which the server returns a oneshot receiver.
-    pub fn rpc<Req, Res>(&self, msg: Req) -> impl Future<Output = Result<Res>> + Send + 'static + use<Req, Res, S>
+    pub fn rpc<Req, Res>(
+        &self,
+        msg: Req,
+    ) -> impl Future<Output = Result<Res>> + Send + 'static + use<Req, Res, S>
     where
         S: From<Req>,
         S::Message: From<WithChannels<Req, S>>,
@@ -1442,7 +1445,8 @@ impl<S: Service> Client<S> {
         &self,
         msg: Req,
         local_update_cap: usize,
-    ) -> impl Future<Output = Result<(mpsc::Sender<Update>, oneshot::Receiver<Res>)>> + use<Req, Update, Res, S>
+    ) -> impl Future<Output = Result<(mpsc::Sender<Update>, oneshot::Receiver<Res>)>>
+    + use<Req, Update, Res, S>
     where
         S: From<Req>,
         S::Message: From<WithChannels<Req, S>>,
@@ -1478,7 +1482,10 @@ impl<S: Service> Client<S> {
         msg: Req,
         local_update_cap: usize,
         local_response_cap: usize,
-    ) -> impl Future<Output = Result<(mpsc::Sender<Update>, mpsc::Receiver<Res>)>> + Send + 'static + use<Req, Update, Res, S>
+    ) -> impl Future<Output = Result<(mpsc::Sender<Update>, mpsc::Receiver<Res>)>>
+    + Send
+    + 'static
+    + use<Req, Update, Res, S>
     where
         S: From<Req>,
         S::Message: From<WithChannels<Req, S>>,
@@ -1511,7 +1518,10 @@ impl<S: Service> Client<S> {
     /// Performs a request for which the server returns nothing.
     ///
     /// The returned future completes once the message is sent.
-    pub fn notify<Req>(&self, msg: Req) -> impl Future<Output = Result<()>> + Send + 'static + use<Req, S>
+    pub fn notify<Req>(
+        &self,
+        msg: Req,
+    ) -> impl Future<Output = Result<()>> + Send + 'static + use<Req, S>
     where
         S: From<Req>,
         S::Message: From<WithChannels<Req, S>>,
@@ -1541,7 +1551,10 @@ impl<S: Service> Client<S> {
     /// Compared to [Self::notify], this variant takes a future that returns true
     /// if 0rtt has been accepted. If not, the data is sent again via the same
     /// remote channel. For local requests, the future is ignored.
-    pub fn notify_0rtt<Req>(&self, msg: Req) -> impl Future<Output = Result<()>> + Send + 'static + use<Req, S>
+    pub fn notify_0rtt<Req>(
+        &self,
+        msg: Req,
+    ) -> impl Future<Output = Result<()>> + Send + 'static + use<Req, S>
     where
         S: From<Req>,
         S::Message: From<WithChannels<Req, S>>,
@@ -1578,7 +1591,10 @@ impl<S: Service> Client<S> {
     /// Compared to [Self::rpc], this variant takes a future that returns true
     /// if 0rtt has been accepted. If not, the data is sent again via the same
     /// remote channel. For local requests, the future is ignored.
-    pub fn rpc_0rtt<Req, Res>(&self, msg: Req) -> impl Future<Output = Result<Res>> + Send + 'static + use<Req, Res, S>
+    pub fn rpc_0rtt<Req, Res>(
+        &self,
+        msg: Req,
+    ) -> impl Future<Output = Result<Res>> + Send + 'static + use<Req, Res, S>
     where
         S: From<Req>,
         S::Message: From<WithChannels<Req, S>>,
@@ -1832,16 +1848,17 @@ pub mod rpc {
     use quinn::ConnectionError;
     use serde::de::DeserializeOwned;
     use smallvec::SmallVec;
-    use tracing::{debug, error_span, trace, warn, Instrument};
+    use tracing::{Instrument, debug, error_span, trace, warn};
 
     use crate::{
+        LocalSender, RequestError, RpcMessage, Service,
         channel::{
+            SendError,
             mpsc::{self, DynReceiver, DynSender},
             none::NoSender,
-            oneshot, SendError,
+            oneshot,
         },
-        util::{now_or_never, AsyncReadVarintExt, WriteVarintExt},
-        LocalSender, RequestError, RpcMessage, Service,
+        util::{AsyncReadVarintExt, WriteVarintExt, now_or_never},
     };
 
     /// Default max message size (16 MiB).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -498,7 +498,7 @@ pub mod channel {
             ///
             /// If this is a boxed sender that represents a remote connection, sending may yield or fail with an io error.
             /// Local senders will never yield, but can fail if the receiver has been closed.
-            pub async fn send(self, value: T) -> std::result::Result<(), SendError> {
+            pub async fn send(self, value: T) -> Result<(), SendError> {
                 match self {
                     Sender::Tokio(tx) => tx.send(value).map_err(|_| e!(SendError::ReceiverClosed)),
                     Sender::Boxed(f) => f(value).await,
@@ -569,7 +569,7 @@ pub mod channel {
         }
 
         impl<T> Future for Receiver<T> {
-            type Output = std::result::Result<T, RecvError>;
+            type Output = Result<T, RecvError>;
 
             fn poll(self: Pin<&mut Self>, cx: &mut task::Context) -> task::Poll<Self::Output> {
                 match self.get_mut() {
@@ -814,14 +814,7 @@ pub mod channel {
         pub trait DynReceiver<T>: Debug + Send + Sync + 'static {
             fn recv(
                 &mut self,
-            ) -> Pin<
-                Box<
-                    dyn Future<Output = std::result::Result<Option<T>, RecvError>>
-                        + Send
-                        + Sync
-                        + '_,
-                >,
-            >;
+            ) -> Pin<Box<dyn Future<Output = Result<Option<T>, RecvError>> + Send + Sync + '_>>;
         }
 
         impl<T> Debug for Sender<T> {
@@ -846,7 +839,7 @@ pub mod channel {
             /// then the sender will be closed and further sends will return an [`SendError::Io`]
             /// with [`std::io::ErrorKind::BrokenPipe`]. Therefore, make sure to always poll the
             /// future until completion if you want to reuse the sender or any clone afterwards.
-            pub async fn send(&self, value: T) -> std::result::Result<(), SendError> {
+            pub async fn send(&self, value: T) -> Result<(), SendError> {
                 match self {
                     Sender::Tokio(tx) => tx
                         .send(value)
@@ -877,7 +870,7 @@ pub mod channel {
             /// then the sender will be closed and further sends will return an [`SendError::Io`]
             /// with [`std::io::ErrorKind::BrokenPipe`]. Therefore, make sure to always poll the
             /// future until completion if you want to reuse the sender or any clone afterwards.
-            pub async fn try_send(&self, value: T) -> std::result::Result<bool, SendError> {
+            pub async fn try_send(&self, value: T) -> Result<bool, SendError> {
                 match self {
                     Sender::Tokio(tx) => match tx.try_send(value) {
                         Ok(()) => Ok(true),
@@ -906,7 +899,7 @@ pub mod channel {
             /// cleanly closed the connection.
             ///
             /// Returns an an io error if there was an error receiving the message.
-            pub async fn recv(&mut self) -> std::result::Result<Option<T>, RecvError> {
+            pub async fn recv(&mut self) -> Result<Option<T>, RecvError> {
                 match self {
                     Self::Tokio(rx) => Ok(rx.recv().await),
                     Self::Boxed(rx) => Ok(rx.recv().await?),
@@ -951,7 +944,7 @@ pub mod channel {
             #[cfg(feature = "stream")]
             pub fn into_stream(
                 self,
-            ) -> impl n0_future::Stream<Item = std::result::Result<T, RecvError>> + Send + Sync + 'static
+            ) -> impl n0_future::Stream<Item = Result<T, RecvError>> + Send + Sync + 'static
             {
                 n0_future::stream::unfold(self, |mut recv| async move {
                     recv.recv().await.transpose().map(|msg| (msg, recv))
@@ -1069,14 +1062,8 @@ pub mod channel {
         {
             fn recv(
                 &mut self,
-            ) -> Pin<
-                Box<
-                    dyn Future<Output = std::result::Result<Option<U>, RecvError>>
-                        + Send
-                        + Sync
-                        + '_,
-                >,
-            > {
+            ) -> Pin<Box<dyn Future<Output = Result<Option<U>, RecvError>> + Send + Sync + '_>>
+            {
                 Box::pin(async move {
                     while let Some(msg) = self.receiver.recv().await? {
                         if let Some(v) = (self.f)(msg) {
@@ -1345,9 +1332,7 @@ impl<S: Service> Client<S> {
     #[allow(clippy::type_complexity)]
     pub fn request(
         &self,
-    ) -> impl Future<
-        Output = result::Result<Request<LocalSender<S>, rpc::RemoteSender<S>>, RequestError>,
-    >
+    ) -> impl Future<Output = Result<Request<LocalSender<S>, rpc::RemoteSender<S>>, RequestError>>
     + 'static
     + use<S> {
         #[cfg(feature = "rpc")]
@@ -1768,7 +1753,7 @@ pub enum Error {
 }
 
 /// Type alias for a result with an irpc error type.
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 impl From<Error> for io::Error {
     fn from(e: Error) -> Self {
@@ -1946,7 +1931,7 @@ pub mod rpc {
         /// Open a bidirectional stream to the remote service.
         fn open_bi(
             &self,
-        ) -> BoxFuture<std::result::Result<(quinn::SendStream, quinn::RecvStream), RequestError>>;
+        ) -> BoxFuture<Result<(quinn::SendStream, quinn::RecvStream), RequestError>>;
 
         /// Returns whether 0-RTT data was accepted by the server.
         ///
@@ -1975,8 +1960,7 @@ pub mod rpc {
 
         fn open_bi(
             &self,
-        ) -> BoxFuture<std::result::Result<(quinn::SendStream, quinn::RecvStream), RequestError>>
-        {
+        ) -> BoxFuture<Result<(quinn::SendStream, quinn::RecvStream), RequestError>> {
             let conn = self.clone();
             Box::pin(async move {
                 let pair = conn.open_bi().await?;
@@ -2006,8 +1990,7 @@ pub mod rpc {
 
         fn open_bi(
             &self,
-        ) -> BoxFuture<std::result::Result<(quinn::SendStream, quinn::RecvStream), RequestError>>
-        {
+        ) -> BoxFuture<Result<(quinn::SendStream, quinn::RecvStream), RequestError>> {
             let this = self.0.clone();
             Box::pin(async move {
                 let mut guard = this.connection.lock().await;
@@ -2055,7 +2038,7 @@ pub mod rpc {
 
     pub(crate) fn prepare_write<S: Service>(
         msg: impl Into<S>,
-    ) -> std::result::Result<SmallVec<[u8; 128]>, WriteError> {
+    ) -> Result<SmallVec<[u8; 128]>, WriteError> {
         let msg = msg.into();
         if postcard::experimental::serialized_size(&msg)? as u64 > MAX_MESSAGE_SIZE {
             return Err(e!(WriteError::MaxMessageSizeExceeded));
@@ -2073,7 +2056,7 @@ pub mod rpc {
         pub async fn write(
             self,
             msg: impl Into<S>,
-        ) -> std::result::Result<(quinn::SendStream, quinn::RecvStream), WriteError> {
+        ) -> Result<(quinn::SendStream, quinn::RecvStream), WriteError> {
             let buf = prepare_write(msg)?;
             self.write_raw(&buf).await
         }
@@ -2081,7 +2064,7 @@ pub mod rpc {
         pub(crate) async fn write_raw(
             self,
             buf: &[u8],
-        ) -> std::result::Result<(quinn::SendStream, quinn::RecvStream), WriteError> {
+        ) -> Result<(quinn::SendStream, quinn::RecvStream), WriteError> {
             let RemoteSender(mut send, recv, _) = self;
             send.write_all(buf).await?;
             Ok((send, recv))
@@ -2193,14 +2176,8 @@ pub mod rpc {
     impl<T: RpcMessage> DynReceiver<T> for QuinnReceiver<T> {
         fn recv(
             &mut self,
-        ) -> Pin<
-            Box<
-                dyn Future<Output = std::result::Result<Option<T>, mpsc::RecvError>>
-                    + Send
-                    + Sync
-                    + '_,
-            >,
-        > {
+        ) -> Pin<Box<dyn Future<Output = Result<Option<T>, mpsc::RecvError>> + Send + Sync + '_>>
+        {
             Box::pin(async {
                 let read = &mut self.recv;
                 let Some(size) = read.read_varint_u64().await? else {
@@ -2373,11 +2350,7 @@ pub mod rpc {
 
     /// Type alias for a handler fn for remote requests
     pub type Handler<R> = Arc<
-        dyn Fn(
-                R,
-                quinn::RecvStream,
-                quinn::SendStream,
-            ) -> BoxFuture<std::result::Result<(), SendError>>
+        dyn Fn(R, quinn::RecvStream, quinn::SendStream) -> BoxFuture<Result<(), SendError>>
             + Send
             + Sync
             + 'static,
@@ -2529,7 +2502,7 @@ impl<S: Service> LocalSender<S> {
     pub fn send<T>(
         &self,
         value: impl Into<WithChannels<T, S>>,
-    ) -> impl Future<Output = std::result::Result<(), SendError>> + Send + 'static
+    ) -> impl Future<Output = Result<(), SendError>> + Send + 'static
     where
         T: Channels<S>,
         S::Message: From<WithChannels<T, S>>,
@@ -2542,7 +2515,7 @@ impl<S: Service> LocalSender<S> {
     pub fn send_raw(
         &self,
         value: S::Message,
-    ) -> impl Future<Output = std::result::Result<(), SendError>> + Send + 'static + use<S> {
+    ) -> impl Future<Output = Result<(), SendError>> + Send + 'static + use<S> {
         let x = self.0.clone();
         async move { x.send(value).await }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1012,11 +1012,11 @@ pub mod channel {
                 value: U,
             ) -> Pin<Box<dyn Future<Output = Result<(), SendError>> + Send + '_>> {
                 Box::pin(async move {
-                    if let Some(v) = (self.f)(value) {
+                    match (self.f)(value) { Some(v) => {
                         self.sender.send(v).await
-                    } else {
+                    } _ => {
                         Ok(())
-                    }
+                    }}
                 })
             }
 
@@ -1025,11 +1025,11 @@ pub mod channel {
                 value: U,
             ) -> Pin<Box<dyn Future<Output = Result<bool, SendError>> + Send + '_>> {
                 Box::pin(async move {
-                    if let Some(v) = (self.f)(value) {
+                    match (self.f)(value) { Some(v) => {
                         self.sender.try_send(v).await
-                    } else {
+                    } _ => {
                         Ok(true)
-                    }
+                    }}
                 })
             }
 
@@ -1349,7 +1349,7 @@ impl<S: Service> Client<S> {
         &self,
     ) -> impl Future<
         Output = result::Result<Request<LocalSender<S>, rpc::RemoteSender<S>>, RequestError>,
-    > + 'static {
+    > + 'static + use<S> {
         #[cfg(feature = "rpc")]
         {
             let cloned = match &self.0 {
@@ -1377,7 +1377,7 @@ impl<S: Service> Client<S> {
     }
 
     /// Performs a request for which the server returns a oneshot receiver.
-    pub fn rpc<Req, Res>(&self, msg: Req) -> impl Future<Output = Result<Res>> + Send + 'static
+    pub fn rpc<Req, Res>(&self, msg: Req) -> impl Future<Output = Result<Res>> + Send + 'static + use<Req, Res, S>
     where
         S: From<Req>,
         S::Message: From<WithChannels<Req, S>>,
@@ -1410,7 +1410,7 @@ impl<S: Service> Client<S> {
         &self,
         msg: Req,
         local_response_cap: usize,
-    ) -> impl Future<Output = Result<mpsc::Receiver<Res>>> + Send + 'static
+    ) -> impl Future<Output = Result<mpsc::Receiver<Res>>> + Send + 'static + use<Req, Res, S>
     where
         S: From<Req>,
         S::Message: From<WithChannels<Req, S>>,
@@ -1442,7 +1442,7 @@ impl<S: Service> Client<S> {
         &self,
         msg: Req,
         local_update_cap: usize,
-    ) -> impl Future<Output = Result<(mpsc::Sender<Update>, oneshot::Receiver<Res>)>>
+    ) -> impl Future<Output = Result<(mpsc::Sender<Update>, oneshot::Receiver<Res>)>> + use<Req, Update, Res, S>
     where
         S: From<Req>,
         S::Message: From<WithChannels<Req, S>>,
@@ -1478,7 +1478,7 @@ impl<S: Service> Client<S> {
         msg: Req,
         local_update_cap: usize,
         local_response_cap: usize,
-    ) -> impl Future<Output = Result<(mpsc::Sender<Update>, mpsc::Receiver<Res>)>> + Send + 'static
+    ) -> impl Future<Output = Result<(mpsc::Sender<Update>, mpsc::Receiver<Res>)>> + Send + 'static + use<Req, Update, Res, S>
     where
         S: From<Req>,
         S::Message: From<WithChannels<Req, S>>,
@@ -1511,7 +1511,7 @@ impl<S: Service> Client<S> {
     /// Performs a request for which the server returns nothing.
     ///
     /// The returned future completes once the message is sent.
-    pub fn notify<Req>(&self, msg: Req) -> impl Future<Output = Result<()>> + Send + 'static
+    pub fn notify<Req>(&self, msg: Req) -> impl Future<Output = Result<()>> + Send + 'static + use<Req, S>
     where
         S: From<Req>,
         S::Message: From<WithChannels<Req, S>>,
@@ -1541,7 +1541,7 @@ impl<S: Service> Client<S> {
     /// Compared to [Self::notify], this variant takes a future that returns true
     /// if 0rtt has been accepted. If not, the data is sent again via the same
     /// remote channel. For local requests, the future is ignored.
-    pub fn notify_0rtt<Req>(&self, msg: Req) -> impl Future<Output = Result<()>> + Send + 'static
+    pub fn notify_0rtt<Req>(&self, msg: Req) -> impl Future<Output = Result<()>> + Send + 'static + use<Req, S>
     where
         S: From<Req>,
         S::Message: From<WithChannels<Req, S>>,
@@ -1578,7 +1578,7 @@ impl<S: Service> Client<S> {
     /// Compared to [Self::rpc], this variant takes a future that returns true
     /// if 0rtt has been accepted. If not, the data is sent again via the same
     /// remote channel. For local requests, the future is ignored.
-    pub fn rpc_0rtt<Req, Res>(&self, msg: Req) -> impl Future<Output = Result<Res>> + Send + 'static
+    pub fn rpc_0rtt<Req, Res>(&self, msg: Req) -> impl Future<Output = Result<Res>> + Send + 'static + use<Req, Res, S>
     where
         S: From<Req>,
         S::Message: From<WithChannels<Req, S>>,
@@ -1627,7 +1627,7 @@ impl<S: Service> Client<S> {
         &self,
         msg: Req,
         local_response_cap: usize,
-    ) -> impl Future<Output = Result<mpsc::Receiver<Res>>> + Send + 'static
+    ) -> impl Future<Output = Result<mpsc::Receiver<Res>>> + Send + 'static + use<Req, Res, S>
     where
         S: From<Req>,
         S::Message: From<WithChannels<Req, S>>,
@@ -2525,7 +2525,7 @@ impl<S: Service> LocalSender<S> {
     pub fn send_raw(
         &self,
         value: S::Message,
-    ) -> impl Future<Output = std::result::Result<(), SendError>> + Send + 'static {
+    ) -> impl Future<Output = std::result::Result<(), SendError>> + Send + 'static + use<S> {
         let x = self.0.clone();
         async move { x.send(value).await }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,8 +74,9 @@
 //!
 //! ```
 //! use irpc::{
+//!     Client, WithChannels,
 //!     channel::{mpsc, oneshot},
-//!     rpc_requests, Client, WithChannels,
+//!     rpc_requests,
 //! };
 //! use serde::{Deserialize, Serialize};
 //!
@@ -247,8 +248,9 @@ use std::{fmt::Debug, future::Future, io, marker::PhantomData, ops::Deref};
 /// With `wrap`:
 /// ```
 /// use irpc::{
+///     Client,
 ///     channel::{mpsc, oneshot},
-///     rpc_requests, Client,
+///     rpc_requests,
 /// };
 /// use serde::{Deserialize, Serialize};
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,7 @@
 //! quic-rpc, this crate does not abstract over the stream type and is focused
 //! on [iroh](https://docs.rs/iroh/latest/iroh/index.html) and our [iroh quinn fork](https://docs.rs/iroh-quinn/latest/iroh-quinn/index.html).
 #![cfg_attr(quicrpc_docsrs, feature(doc_cfg))]
-use std::{fmt::Debug, future::Future, io, marker::PhantomData, ops::Deref, result};
+use std::{fmt::Debug, future::Future, io, marker::PhantomData, ops::Deref};
 
 /// Processes an RPC request enum and generates trait implementations for use with `irpc`.
 ///
@@ -1332,9 +1332,8 @@ impl<S: Service> Client<S> {
     #[allow(clippy::type_complexity)]
     pub fn request(
         &self,
-    ) -> impl Future<Output = Result<Request<LocalSender<S>, rpc::RemoteSender<S>>, RequestError>>
-    + 'static
-    + use<S> {
+    ) -> impl Future<Output = Result<Request<LocalSender<S>, rpc::RemoteSender<S>>, RequestError>> + use<S>
+    {
         #[cfg(feature = "rpc")]
         {
             let cloned = match &self.0 {

--- a/src/util.rs
+++ b/src/util.rs
@@ -219,15 +219,14 @@ mod varint_util {
 
             // Read a single byte
             let res = reader.read_u8().await;
-            if shift == 0 {
-                if let Err(cause) = res {
+            if shift == 0
+                && let Err(cause) = res {
                     if cause.kind() == io::ErrorKind::UnexpectedEof {
                         return Ok(None);
                     } else {
                         return Err(cause);
                     }
                 }
-            }
 
             let byte = res?;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,7 +8,7 @@ mod quinn_setup_utils {
     use std::{sync::Arc, time::Duration};
 
     use n0_error::{Result, StdResultExt};
-    use quinn::{crypto::rustls::QuicClientConfig, ClientConfig, ServerConfig};
+    use quinn::{ClientConfig, ServerConfig, crypto::rustls::QuicClientConfig};
 
     /// Create a quinn client config and trusts given certificates.
     ///
@@ -189,7 +189,7 @@ mod varint_util {
         io::{self, Error},
     };
 
-    use serde::{de::DeserializeOwned, Serialize};
+    use serde::{Serialize, de::DeserializeOwned};
     use smallvec::SmallVec;
     use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
@@ -220,13 +220,14 @@ mod varint_util {
             // Read a single byte
             let res = reader.read_u8().await;
             if shift == 0
-                && let Err(cause) = res {
-                    if cause.kind() == io::ErrorKind::UnexpectedEof {
-                        return Ok(None);
-                    } else {
-                        return Err(cause);
-                    }
+                && let Err(cause) = res
+            {
+                if cause.kind() == io::ErrorKind::UnexpectedEof {
+                    return Ok(None);
+                } else {
+                    return Err(cause);
                 }
+            }
 
             let byte = res?;
 

--- a/tests/mpsc_channel.rs
+++ b/tests/mpsc_channel.rs
@@ -7,8 +7,8 @@ use std::{
 
 use irpc::{
     channel::{
-        mpsc::{self, Receiver, RecvError},
         SendError,
+        mpsc::{self, Receiver, RecvError},
     },
     util::AsyncWriteVarintExt,
 };
@@ -46,7 +46,7 @@ async fn mpsc_sender_clone_closed_error() -> TestResult<()> {
         loop {
             match send3.send(vec![1, 2, 3]).await {
                 Err(SendError::Io { source, .. }) if source.kind() == ErrorKind::BrokenPipe => {
-                    break
+                    break;
                 }
                 _ => {}
             };
@@ -94,7 +94,7 @@ async fn mpsc_sender_clone_drop_error() -> TestResult<()> {
         loop {
             match send3.send(vec![1, 2, 3]).await {
                 Err(SendError::Io { source, .. }) if source.kind() == ErrorKind::BrokenPipe => {
-                    break
+                    break;
                 }
                 _ => {}
             };

--- a/tests/oneshot_channel.rs
+++ b/tests/oneshot_channel.rs
@@ -4,8 +4,8 @@ use std::io::{self, ErrorKind};
 
 use irpc::{
     channel::{
-        oneshot::{self, RecvError},
         SendError,
+        oneshot::{self, RecvError},
     },
     util::AsyncWriteVarintExt,
 };


### PR DESCRIPTION
Migrates to edition 2024