### PR TITLE
refactor: simplify docsrs cfg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,13 +103,17 @@ members = ["irpc-derive", "irpc-iroh"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "quicrpc_docsrs"]
+rustdoc-args = ["--cfg", "irpc_docsrs"]
 
 [package.metadata.release]
 pre-release-hook = ["git", "cliff", "--unreleased", "--tag", "{{version}}", "--prepend", "CHANGELOG.md"]
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ["cfg(quicrpc_docsrs)"] }
+# Documents which cargo features an API needs. Preview locally with:
+# RUSTDOCFLAGS="--cfg irpc_docsrs" cargo +nightly doc --all-features.
+# We use our own irpc_docsrs rather than the common docsrs so the cfg
+# does not leak into dependencies, some of which fail to build under it.
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(irpc_docsrs)"] }
 
 [workspace.dependencies]
 anyhow = { version = "1" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,7 @@
 //! framework for any transport with cheap streams such as QUIC. Compared to
 //! quic-rpc, this crate does not abstract over the stream type and is focused
 //! on [iroh](https://docs.rs/iroh/latest/iroh/index.html) and our [noq](https://docs.rs/noq/latest/noq/index.html).
-#![cfg_attr(quicrpc_docsrs, feature(doc_cfg))]
+#![cfg_attr(irpc_docsrs, feature(doc_cfg))]
 use std::{fmt::Debug, future::Future, io, marker::PhantomData, ops::Deref};
 
 /// Processes an RPC request enum and generates trait implementations for use with `irpc`.
@@ -301,7 +301,6 @@ use std::{fmt::Debug, future::Future, io, marker::PhantomData, ops::Deref};
 /// [`WithChannels<T, Service>`]: WithChannels
 /// [`Channels<S>`]: Channels
 #[cfg(feature = "derive")]
-#[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "derive")))]
 pub use irpc_derive::rpc_requests;
 #[cfg(feature = "rpc")]
 use n0_error::AnyError;
@@ -320,7 +319,6 @@ use crate::channel::SendError;
 
 pub mod channel;
 #[cfg(feature = "rpc")]
-#[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "rpc")))]
 pub mod span_propagation;
 #[cfg(test)]
 mod tests;
@@ -330,7 +328,6 @@ pub mod rpc {
     pub struct RemoteSender<S>(std::marker::PhantomData<S>);
 }
 #[cfg(feature = "rpc")]
-#[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "rpc")))]
 pub mod rpc;
 
 mod sealed {
@@ -409,7 +406,6 @@ pub struct WithChannels<I: Channels<S>, S: Service> {
     pub rx: <I as Channels<S>>::Rx,
     /// The current span where the full message was created.
     #[cfg(feature = "spans")]
-    #[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "spans")))]
     pub span: tracing::Span,
 }
 
@@ -873,10 +869,8 @@ impl<S: Service> Client<S> {
 pub(crate) enum ClientInner<M> {
     Local(crate::channel::mpsc::Sender<M>),
     #[cfg(feature = "rpc")]
-    #[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "rpc")))]
     Remote(Box<dyn rpc::RemoteConnection>),
     #[cfg(not(feature = "rpc"))]
-    #[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "rpc")))]
     #[allow(dead_code)]
     Remote(PhantomData<M>),
 }
@@ -912,7 +906,6 @@ impl<M> ClientInner<M> {
 pub enum RequestError {
     /// Error in noq during connect
     #[cfg(feature = "rpc")]
-    #[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "rpc")))]
     #[error("Error establishing connection")]
     Connect {
         #[error(std_err)]
@@ -920,7 +913,6 @@ pub enum RequestError {
     },
     /// Error in noq when the connection already exists, when opening a stream pair
     #[cfg(feature = "rpc")]
-    #[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "rpc")))]
     #[error("Error opening stream")]
     Connection {
         #[error(std_err)]
@@ -928,7 +920,6 @@ pub enum RequestError {
     },
     /// Generic error for non-noq transports
     #[cfg(feature = "rpc")]
-    #[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "rpc")))]
     #[error("Error opening stream")]
     Other { source: AnyError },
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,7 +3,6 @@
 //! This module contains utilities to read and write varints, as well as
 //! functions to set up noq endpoints for local rpc and testing.
 #[cfg(feature = "noq_endpoint_setup")]
-#[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "noq_endpoint_setup")))]
 mod noq_setup_utils {
     use std::{sync::Arc, time::Duration};
 
@@ -175,14 +174,9 @@ mod noq_setup_utils {
     }
 }
 #[cfg(feature = "noq_endpoint_setup")]
-#[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "noq_endpoint_setup")))]
 pub use noq_setup_utils::*;
 
 #[cfg(any(feature = "rpc", feature = "varint-util"))]
-#[cfg_attr(
-    quicrpc_docsrs,
-    doc(cfg(any(feature = "rpc", feature = "varint-util")))
-)]
 mod varint_util {
     use std::{
         future::Future,
@@ -392,10 +386,6 @@ mod varint_util {
 }
 
 #[cfg(any(feature = "rpc", feature = "varint-util"))]
-#[cfg_attr(
-    quicrpc_docsrs,
-    doc(cfg(any(feature = "rpc", feature = "varint-util")))
-)]
 pub use varint_util::{AsyncReadVarintExt, AsyncWriteVarintExt, WriteVarintExt};
 
 mod fuse_wrapper {


### PR DESCRIPTION
Cleans up the feature-gate doc machinery left over from the quic-rpc origins.

- **Drop the per-item `doc(cfg(...))` annotations.** Rustdoc now infers feature badges from the real `#[cfg(...)]` gates automatically. `doc_auto_cfg` was merged into `doc_cfg` in Rust 1.92 ([rust-lang/rust#138907](https://github.com/rust-lang/rust/pull/138907)), so it is the default when `feature(doc_cfg)` is on. `feature(doc_cfg)` is nightly-only, but it is gated behind the `irpc_docsrs` cfg that only docs.rs sets. Regular builds never see it, so our MSRV stays at 1.91 on stable.
- **Rename `quicrpc_docsrs` to `irpc_docsrs`**, matching the crate name and the `iroh_docsrs` convention.

We keep a crate-specific cfg rather than the common `docsrs` because `--cfg docsrs` leaks into dependencies. A full doc build fails when `cordyceps` enables now-removed features behind `#[cfg(docsrs)]`. Using `irpc_docsrs` sidesteps that.